### PR TITLE
Add help center content for Rules

### DIFF
--- a/x-pack/plugins/triggers_actions_ui/docs/rules_documentation.tsx
+++ b/x-pack/plugins/triggers_actions_ui/docs/rules_documentation.tsx
@@ -1,0 +1,106 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { FormattedMessage } from '@kbn/i18n-react';
+
+import { EuiText } from '@elastic/eui';
+
+export function RulesHelp() {
+  return (
+    <>
+      <EuiText>
+        <p>
+          <FormattedMessage
+            id="rules.welcomePage.quickIntroDescription"
+            defaultMessage="Rules detect complex conditions and trigger actions when those conditions are met."
+          />
+        </p>
+        <p>
+          <FormattedMessage
+            id="rules.welcomePage.componentsDescription"
+            defaultMessage="A rule consists of three main parts:"
+          />
+          <ul>
+            <li>
+              <FormattedMessage
+                id="rules.welcomePage.components.conditions"
+                defaultMessage="{conditionsText}: What needs to be detected?"
+                values={{
+                  conditionsText: <i>Conditions</i>,
+                }}
+              />
+            </li>
+            <li>
+              <FormattedMessage
+                id="rules.welcomePage.components.schedule"
+                defaultMessage="{scheduleText}: How often should detection checks run?"
+                values={{
+                  scheduleText: <i>Schedule</i>,
+                }}
+              />
+            </li>
+            <li>
+              <FormattedMessage
+                id="rules.welcomePage.components.actions"
+                defaultMessage="{actionsText}: What happens when a condition is detected?"
+                values={{
+                  actionsText: <i>Actions</i>,
+                }}
+              />
+            </li>
+          </ul>
+        </p>
+        <h4>
+          <FormattedMessage id="rules.welcomePage.conditions" defaultMessage="Conditions" />
+        </h4>
+        <p>
+          <FormattedMessage
+            id="console.welcomePage.conditionsDescription1"
+            defaultMessage="Kibana rules have the flexibility to support a wide range of conditions, anything from the results of a simple Elasticsearch query to heavy computations involving data from multiple sources or external systems."
+          />
+        </p>
+        <p>
+          <FormattedMessage
+            id="console.welcomePage.conditionsExample"
+            defaultMessage="For example, you can create a rule that checks for average CPU usage that is greater than 90% on each server for the last two minutes."
+          />
+        </p>
+        <h4>
+          <FormattedMessage id="rules.welcomePage.schedule" defaultMessage="Schedule" />
+        </h4>
+        <p>
+          <FormattedMessage
+            id="console.welcomePage.scheduleDescription"
+            defaultMessage="A rule's schedule is the approximate interval between its checks. It can range from a few seconds to months."
+          />
+        </p>
+        <p>
+          <FormattedMessage
+            id="console.welcomePage.scheduleExample"
+            defaultMessage="For example, your rule can check its conditions every minute."
+          />
+        </p>
+        <h4>
+          <FormattedMessage id="rules.welcomePage.actions" defaultMessage="Actions" />
+        </h4>
+        <p>
+          <FormattedMessage
+            id="console.welcomePage.actionDescription"
+            defaultMessage="You can add one or more actions to your rule to generate notifications when its conditions are met and when they are no longer met."
+          />
+        </p>
+        <p>
+          <FormattedMessage
+            id="console.welcomePage.actionExample"
+            defaultMessage="For example, your rule can send a warning email message that indicates which server has high CPU usage."
+          />
+        </p>
+      </EuiText>
+    </>
+  );
+}

--- a/x-pack/plugins/triggers_actions_ui/public/application/home.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/home.tsx
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { i18n } from '@kbn/i18n';
 import React, { useState, lazy, useEffect, useCallback } from 'react';
 import { RouteComponentProps, Switch, Redirect } from 'react-router-dom';
 import { Route } from '@kbn/shared-ux-router';
@@ -21,6 +22,7 @@ import { HealthCheck } from './components/health_check';
 import { HealthContextProvider } from './context/health_context';
 import { useKibana } from '../common/lib/kibana';
 import { suspendedComponentWithProps } from './lib/suspended_component_with_props';
+import { RulesHelp } from '../../docs/rules_documentation';
 
 const RulesList = lazy(() => import('./sections/rules_list/components/rules_list'));
 const LogsList = lazy(() => import('./sections/logs_list/components/logs_list'));
@@ -44,6 +46,21 @@ export const TriggersActionsUIHome: React.FunctionComponent<RouteComponentProps<
     id: Section;
     name: React.ReactNode;
   }> = [];
+
+  chrome.setHelpExtension({
+    appName: i18n.translate('xpack.triggersActionsUI.helpMenu.appName', {
+      defaultMessage: 'Rules',
+    }),
+    links: [
+      {
+        iconType: 'questionInCircle',
+        linkType: 'documentation',
+        title: 'What is a rule?',
+        priority: 100,
+        content: <RulesHelp />,
+      },
+    ],
+  });
 
   tabs.push({
     id: 'rules',


### PR DESCRIPTION
## Summary

This PR copies the Console help in https://github.com/elastic/kibana/pull/157300 to add very simple text in the Stack Management > Rules UI.  The text is a shortened version of what's in the documentation here: https://www.elastic.co/guide/en/kibana/master/alerting-getting-started.html

### Screenshots

![image](https://github.com/Heenawter/kibana/assets/26471269/c916fe4f-6df6-4499-a1ac-dcf58db4500e)

![image](https://github.com/Heenawter/kibana/assets/26471269/ec5f0897-119b-48f0-bd1e-02c1682b2e95)
