### PR TITLE
[SpaceTime] [Saved Search] Inline editing

### DIFF
--- a/packages/kbn-esql-utils/src/utils/get_esql_with_safe_limit.ts
+++ b/packages/kbn-esql-utils/src/utils/get_esql_with_safe_limit.ts
@@ -26,7 +26,7 @@ export function getESQLWithSafeLimit(esql: string, limit: number): string {
   return parts
     .map((part, i) => {
       if (i === index) {
-        return `${part.trim()} \n| LIMIT ${limit}`;
+        return `${part.trim()} | limit ${limit}`;
       }
       return part;
     })

--- a/packages/presentation/presentation_containers/interfaces/presentation_container.ts
+++ b/packages/presentation/presentation_containers/interfaces/presentation_container.ts
@@ -6,6 +6,7 @@
  * Side Public License, v 1.
  */
 
+import { Reference } from '@kbn/content-management-utils';
 import { apiHasParentApi, apiHasUniqueId, PublishingSubject } from '@kbn/presentation-publishing';
 import { BehaviorSubject, combineLatest, isObservable, map, Observable, of, switchMap } from 'rxjs';
 import { apiCanAddNewPanel, CanAddNewPanel } from './can_add_new_panel';
@@ -13,6 +14,7 @@ import { apiCanAddNewPanel, CanAddNewPanel } from './can_add_new_panel';
 export interface PanelPackage<SerializedState extends object = object> {
   panelType: string;
   initialState?: SerializedState;
+  references?: Reference[];
 }
 
 export interface PresentationContainer extends CanAddNewPanel {

--- a/src/plugins/dashboard/public/dashboard_container/embeddable/create/create_dashboard.ts
+++ b/src/plugins/dashboard/public/dashboard_container/embeddable/create/create_dashboard.ts
@@ -365,6 +365,7 @@ export const initializeDashboard = async ({
       const stopSyncingUnifiedSearchState =
         syncUnifiedSearchState.bind(dashboardContainer)(kbnUrlStateStorage);
       dashboardContainer.stopSyncingWithUnifiedSearch = () => {
+        console.log('stopSyncingWithUnifiedSearch');
         stopSyncingUnifiedSearchState();
         stopSyncingQueryServiceStateWithUrl();
       };

--- a/src/plugins/dashboard/public/dashboard_container/embeddable/create/create_dashboard.ts
+++ b/src/plugins/dashboard/public/dashboard_container/embeddable/create/create_dashboard.ts
@@ -365,7 +365,6 @@ export const initializeDashboard = async ({
       const stopSyncingUnifiedSearchState =
         syncUnifiedSearchState.bind(dashboardContainer)(kbnUrlStateStorage);
       dashboardContainer.stopSyncingWithUnifiedSearch = () => {
-        console.log('stopSyncingWithUnifiedSearch');
         stopSyncingUnifiedSearchState();
         stopSyncingQueryServiceStateWithUrl();
       };

--- a/src/plugins/dashboard/public/dashboard_container/embeddable/create/unified_search/sync_dashboard_unified_search_state.ts
+++ b/src/plugins/dashboard/public/dashboard_container/embeddable/create/unified_search/sync_dashboard_unified_search_state.ts
@@ -44,6 +44,7 @@ export function syncUnifiedSearchState(
     const {
       explicitInput: { filters, query },
     } = this.getState();
+    if (this.ignoreUnifiedSearch) return;
     OnFiltersChange$.next({
       filters: filters ?? [],
       query: query ?? queryString.getDefaultQuery(),
@@ -66,6 +67,7 @@ export function syncUnifiedSearchState(
       set: ({ filters: newFilters, query: newQuery }) => {
         intermediateFilterState.filters = cleanFiltersForSerialize(newFilters);
         intermediateFilterState.query = newQuery;
+        if (this.ignoreUnifiedSearch) return;
         this.dispatch.setFiltersAndQuery(intermediateFilterState);
       },
       state$: OnFiltersChange$.pipe(distinctUntilChanged()),

--- a/src/plugins/dashboard/public/dashboard_container/embeddable/dashboard_container.tsx
+++ b/src/plugins/dashboard/public/dashboard_container/embeddable/dashboard_container.tsx
@@ -174,6 +174,7 @@ export class DashboardContainer
   public firstLoad: boolean = true;
   private hadContentfulRender = false;
   private scrollPosition?: number;
+
   public ignoreUnifiedSearch: boolean = false;
 
   // cleanup

--- a/src/plugins/dashboard/public/dashboard_container/embeddable/dashboard_container.tsx
+++ b/src/plugins/dashboard/public/dashboard_container/embeddable/dashboard_container.tsx
@@ -174,6 +174,7 @@ export class DashboardContainer
   public firstLoad: boolean = true;
   private hadContentfulRender = false;
   private scrollPosition?: number;
+  public ignoreDashboardUnsavedChanges: boolean = false;
 
   // cleanup
   public stopSyncingWithUnifiedSearch?: () => void;

--- a/src/plugins/dashboard/public/dashboard_container/embeddable/dashboard_container.tsx
+++ b/src/plugins/dashboard/public/dashboard_container/embeddable/dashboard_container.tsx
@@ -525,6 +525,7 @@ export class DashboardContainer
           ...panelPackage.initialState,
           id: newId,
         },
+        references: panelPackage.references,
       };
       this.updateInput({ panels: { ...otherPanels, [newId]: newPanel } });
       onSuccess(newId, newPanel.explicitInput.title);

--- a/src/plugins/dashboard/public/dashboard_container/embeddable/dashboard_container.tsx
+++ b/src/plugins/dashboard/public/dashboard_container/embeddable/dashboard_container.tsx
@@ -163,6 +163,9 @@ export class DashboardContainer
   private domNode?: HTMLElement;
   private overlayRef?: OverlayRef;
   private allDataViews: DataView[] = [];
+  public dataViews: BehaviorSubject<DataView[] | undefined> = new BehaviorSubject<
+    DataView[] | undefined
+  >(undefined);
 
   // performance monitoring
   public lastLoadStartTime?: number;
@@ -712,6 +715,7 @@ export class DashboardContainer
   public setAllDataViews = (newDataViews: DataView[]) => {
     this.allDataViews = newDataViews;
     this.onDataViewsUpdate$.next(newDataViews);
+    this.dataViews.next(newDataViews);
   };
 
   public getExpandedPanelId = () => {

--- a/src/plugins/dashboard/public/dashboard_container/embeddable/dashboard_container.tsx
+++ b/src/plugins/dashboard/public/dashboard_container/embeddable/dashboard_container.tsx
@@ -174,7 +174,7 @@ export class DashboardContainer
   public firstLoad: boolean = true;
   private hadContentfulRender = false;
   private scrollPosition?: number;
-  public ignoreDashboardUnsavedChanges: boolean = false;
+  public ignoreUnifiedSearch: boolean = false;
 
   // cleanup
   public stopSyncingWithUnifiedSearch?: () => void;

--- a/src/plugins/dashboard/public/dashboard_container/state/dashboard_container_reducers.ts
+++ b/src/plugins/dashboard/public/dashboard_container/state/dashboard_container_reducers.ts
@@ -250,4 +250,8 @@ export const dashboardContainerReducers = {
   setDisableAutoRefresh: (state: DashboardReduxState, action: PayloadAction<boolean>) => {
     state.componentState.disableAutoRefresh = action.payload;
   },
+
+  setDisableFilters: (state: DashboardReduxState, action: PayloadAction<boolean>) => {
+    state.componentState.disableFilters = action.payload;
+  },
 };

--- a/src/plugins/dashboard/public/dashboard_container/state/dashboard_container_reducers.ts
+++ b/src/plugins/dashboard/public/dashboard_container/state/dashboard_container_reducers.ts
@@ -246,4 +246,8 @@ export const dashboardContainerReducers = {
   setDisableQueryInput: (state: DashboardReduxState, action: PayloadAction<boolean>) => {
     state.componentState.disableQueryInput = action.payload;
   },
+
+  setDisableAutoRefresh: (state: DashboardReduxState, action: PayloadAction<boolean>) => {
+    state.componentState.disableAutoRefresh = action.payload;
+  },
 };

--- a/src/plugins/dashboard/public/dashboard_container/state/dashboard_container_reducers.ts
+++ b/src/plugins/dashboard/public/dashboard_container/state/dashboard_container_reducers.ts
@@ -242,4 +242,8 @@ export const dashboardContainerReducers = {
   ) => {
     state.componentState.animatePanelTransforms = action.payload;
   },
+
+  setDisableQueryInput: (state: DashboardReduxState, action: PayloadAction<boolean>) => {
+    state.componentState.disableQueryInput = action.payload;
+  },
 };

--- a/src/plugins/dashboard/public/dashboard_container/state/diffing/dashboard_diffing_integration.ts
+++ b/src/plugins/dashboard/public/dashboard_container/state/diffing/dashboard_diffing_integration.ts
@@ -30,6 +30,7 @@ export const reducersToIgnore: Array<keyof typeof dashboardContainerReducers> = 
   'setFullScreenMode',
   'setExpandedPanelId',
   'setHasUnsavedChanges',
+  'setDisableQueryInput',
 ];
 
 /**

--- a/src/plugins/dashboard/public/dashboard_container/state/diffing/dashboard_diffing_integration.ts
+++ b/src/plugins/dashboard/public/dashboard_container/state/diffing/dashboard_diffing_integration.ts
@@ -123,9 +123,10 @@ export function startDiffingDashboardState(
           explicitInput: currentInput,
           componentState: { lastSavedInput },
         } = this.getState();
-        const unsavedChanges = this.ignoreDashboardUnsavedChanges
-          ? {}
-          : await getDashboardUnsavedChanges.bind(this)(lastSavedInput, currentInput);
+        const unsavedChanges = await getDashboardUnsavedChanges.bind(this)(
+          lastSavedInput,
+          currentInput
+        );
         return unsavedChanges;
       })();
     })

--- a/src/plugins/dashboard/public/dashboard_container/state/diffing/dashboard_diffing_integration.ts
+++ b/src/plugins/dashboard/public/dashboard_container/state/diffing/dashboard_diffing_integration.ts
@@ -31,6 +31,7 @@ export const reducersToIgnore: Array<keyof typeof dashboardContainerReducers> = 
   'setExpandedPanelId',
   'setHasUnsavedChanges',
   'setDisableQueryInput',
+  'setDisableAutoRefresh',
 ];
 
 /**

--- a/src/plugins/dashboard/public/dashboard_container/state/diffing/dashboard_diffing_integration.ts
+++ b/src/plugins/dashboard/public/dashboard_container/state/diffing/dashboard_diffing_integration.ts
@@ -32,6 +32,7 @@ export const reducersToIgnore: Array<keyof typeof dashboardContainerReducers> = 
   'setHasUnsavedChanges',
   'setDisableQueryInput',
   'setDisableAutoRefresh',
+  'setDisableFilters',
 ];
 
 /**

--- a/src/plugins/dashboard/public/dashboard_container/state/diffing/dashboard_diffing_integration.ts
+++ b/src/plugins/dashboard/public/dashboard_container/state/diffing/dashboard_diffing_integration.ts
@@ -123,10 +123,9 @@ export function startDiffingDashboardState(
           explicitInput: currentInput,
           componentState: { lastSavedInput },
         } = this.getState();
-        const unsavedChanges = await getDashboardUnsavedChanges.bind(this)(
-          lastSavedInput,
-          currentInput
-        );
+        const unsavedChanges = this.ignoreDashboardUnsavedChanges
+          ? {}
+          : await getDashboardUnsavedChanges.bind(this)(lastSavedInput, currentInput);
         return unsavedChanges;
       })();
     })

--- a/src/plugins/dashboard/public/dashboard_container/types.ts
+++ b/src/plugins/dashboard/public/dashboard_container/types.ts
@@ -52,6 +52,8 @@ export interface DashboardPublicState {
   scrollToPanelId?: string;
   highlightPanelId?: string;
   focusedPanelId?: string;
+
+  disableQueryInput?: boolean;
 }
 
 export type DashboardLoadType =

--- a/src/plugins/dashboard/public/dashboard_container/types.ts
+++ b/src/plugins/dashboard/public/dashboard_container/types.ts
@@ -54,6 +54,7 @@ export interface DashboardPublicState {
   focusedPanelId?: string;
 
   disableQueryInput?: boolean;
+  disableAutoRefresh?: boolean;
 }
 
 export type DashboardLoadType =

--- a/src/plugins/dashboard/public/dashboard_container/types.ts
+++ b/src/plugins/dashboard/public/dashboard_container/types.ts
@@ -55,6 +55,7 @@ export interface DashboardPublicState {
 
   disableQueryInput?: boolean;
   disableAutoRefresh?: boolean;
+  disableFilters?: boolean;
 }
 
 export type DashboardLoadType =

--- a/src/plugins/dashboard/public/dashboard_top_nav/internal_dashboard_top_nav.tsx
+++ b/src/plugins/dashboard/public/dashboard_top_nav/internal_dashboard_top_nav.tsx
@@ -314,7 +314,6 @@ export function InternalDashboardTopNav({
     return allBadges;
   }, [hasUnsavedChanges, viewMode, hasRunMigrations, showWriteControls, managed]);
 
-  console.log('dashboard.disableQueryInput', dashboard.disableQueryInput);
   return (
     <div className="dashboardTopNav">
       <h1

--- a/src/plugins/dashboard/public/dashboard_top_nav/internal_dashboard_top_nav.tsx
+++ b/src/plugins/dashboard/public/dashboard_top_nav/internal_dashboard_top_nav.tsx
@@ -93,6 +93,7 @@ export function InternalDashboardTopNav({
   const hasRunMigrations = dashboard.select(
     (state) => state.componentState.hasRunClientsideMigrations
   );
+  const disableQueryInput = dashboard.select((state) => state.componentState.disableQueryInput);
   const hasUnsavedChanges = dashboard.select((state) => state.componentState.hasUnsavedChanges);
   const fullScreenMode = dashboard.select((state) => state.componentState.fullScreenMode);
   const savedQueryId = dashboard.select((state) => state.componentState.savedQueryId);
@@ -313,6 +314,7 @@ export function InternalDashboardTopNav({
     return allBadges;
   }, [hasUnsavedChanges, viewMode, hasRunMigrations, showWriteControls, managed]);
 
+  console.log('dashboard.disableQueryInput', dashboard.disableQueryInput);
   return (
     <div className="dashboardTopNav">
       <h1
@@ -323,7 +325,7 @@ export function InternalDashboardTopNav({
       >{`${getDashboardBreadcrumb()} - ${dashboardTitle}`}</h1>
       <TopNavMenu
         {...visibilityProps}
-        // isDisabled={true}
+        // isDisabled={dashboard.ignoreUnifiedSearch}
         query={query}
         badges={badges}
         screenTitle={title}
@@ -338,6 +340,7 @@ export function InternalDashboardTopNav({
             ? setCustomHeaderActionMenu ?? undefined
             : setHeaderActionMenu
         }
+        disableQueryInput={disableQueryInput}
         className={fullScreenMode ? 'kbnTopNavMenu-isFullScreen' : undefined}
         config={
           visibilityProps.showTopNavMenu

--- a/src/plugins/dashboard/public/dashboard_top_nav/internal_dashboard_top_nav.tsx
+++ b/src/plugins/dashboard/public/dashboard_top_nav/internal_dashboard_top_nav.tsx
@@ -104,6 +104,8 @@ export function InternalDashboardTopNav({
   const query = dashboard.select((state) => state.explicitInput.query);
   const title = dashboard.select((state) => state.explicitInput.title);
 
+  // const disableQueryBar = dashboard.select((state) => state.componentState.disableQueryBar);
+
   // store data views in state & subscribe to dashboard data view changes.
   const [allDataViews, setAllDataViews] = useState<DataView[]>([]);
   useEffect(() => {
@@ -321,6 +323,7 @@ export function InternalDashboardTopNav({
       >{`${getDashboardBreadcrumb()} - ${dashboardTitle}`}</h1>
       <TopNavMenu
         {...visibilityProps}
+        // isDisabled={true}
         query={query}
         badges={badges}
         screenTitle={title}

--- a/src/plugins/dashboard/public/dashboard_top_nav/internal_dashboard_top_nav.tsx
+++ b/src/plugins/dashboard/public/dashboard_top_nav/internal_dashboard_top_nav.tsx
@@ -95,6 +95,7 @@ export function InternalDashboardTopNav({
   );
   const disableQueryInput = dashboard.select((state) => state.componentState.disableQueryInput);
   const disableAutoRefresh = dashboard.select((state) => state.componentState.disableAutoRefresh);
+  const disableFilters = dashboard.select((state) => state.componentState.disableFilters);
   const hasUnsavedChanges = dashboard.select((state) => state.componentState.hasUnsavedChanges);
   const fullScreenMode = dashboard.select((state) => state.componentState.fullScreenMode);
   const savedQueryId = dashboard.select((state) => state.componentState.savedQueryId);
@@ -341,6 +342,7 @@ export function InternalDashboardTopNav({
             : setHeaderActionMenu
         }
         disableQueryInput={disableQueryInput}
+        showFilterBar={!disableFilters}
         disableAutoRefresh={disableAutoRefresh}
         className={fullScreenMode ? 'kbnTopNavMenu-isFullScreen' : undefined}
         config={

--- a/src/plugins/dashboard/public/dashboard_top_nav/internal_dashboard_top_nav.tsx
+++ b/src/plugins/dashboard/public/dashboard_top_nav/internal_dashboard_top_nav.tsx
@@ -94,6 +94,7 @@ export function InternalDashboardTopNav({
     (state) => state.componentState.hasRunClientsideMigrations
   );
   const disableQueryInput = dashboard.select((state) => state.componentState.disableQueryInput);
+  const disableAutoRefresh = dashboard.select((state) => state.componentState.disableAutoRefresh);
   const hasUnsavedChanges = dashboard.select((state) => state.componentState.hasUnsavedChanges);
   const fullScreenMode = dashboard.select((state) => state.componentState.fullScreenMode);
   const savedQueryId = dashboard.select((state) => state.componentState.savedQueryId);
@@ -340,6 +341,7 @@ export function InternalDashboardTopNav({
             : setHeaderActionMenu
         }
         disableQueryInput={disableQueryInput}
+        disableAutoRefresh={disableAutoRefresh}
         className={fullScreenMode ? 'kbnTopNavMenu-isFullScreen' : undefined}
         config={
           visibilityProps.showTopNavMenu

--- a/src/plugins/discover/kibana.jsonc
+++ b/src/plugins/discover/kibana.jsonc
@@ -43,7 +43,13 @@
       "observabilityAIAssistant",
       "aiops"
     ],
-    "requiredBundles": ["kibanaUtils", "kibanaReact", "unifiedSearch", "savedObjects"],
+    "requiredBundles": [
+      "kibanaUtils",
+      "kibanaReact",
+      "unifiedSearch",
+      "savedObjects",
+      "textBasedLanguages"
+    ],
     "extraPublicDirs": ["common"]
   }
 }

--- a/src/plugins/discover/kibana.jsonc
+++ b/src/plugins/discover/kibana.jsonc
@@ -26,7 +26,8 @@
       "unifiedDocViewer",
       "unifiedSearch",
       "unifiedHistogram",
-      "contentManagement"
+      "contentManagement",
+      "presentationUtil"
     ],
     "optionalPlugins": [
       "dataVisualizer",

--- a/src/plugins/discover/public/embeddable/actions/create_saved_search_action.ts
+++ b/src/plugins/discover/public/embeddable/actions/create_saved_search_action.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { SearchSource } from '@kbn/data-plugin/common';
+import { DataView } from '@kbn/data-views-plugin/common';
+import { DataTableRecord, SEARCH_EMBEDDABLE_TYPE } from '@kbn/discover-utils';
+import { embeddableInputToSubject } from '@kbn/embeddable-plugin/public';
+import { getESQLWithSafeLimit } from '@kbn/esql-utils';
+import { i18n } from '@kbn/i18n';
+import { CanAddNewPanel } from '@kbn/presentation-containers';
+import { EmbeddableApiContext } from '@kbn/presentation-publishing';
+import { IncompatibleActionError } from '@kbn/ui-actions-plugin/public';
+import { BehaviorSubject } from 'rxjs';
+import { DiscoverServices } from '../../build_services';
+import {
+  SearchEmbeddableApi,
+  SearchEmbeddableRuntimeState,
+  SearchEmbeddableSerializedState,
+} from '../types';
+
+export const ADD_SEARCH_EMBEDDABLE_ACTION_ID = 'create_saved_search_embeddable';
+
+const parentApiIsCompatible = async (parentApi: unknown): Promise<CanAddNewPanel | undefined> => {
+  const { apiCanAddNewPanel } = await import('@kbn/presentation-containers');
+  // we cannot have an async type check, so return the casted parentApi rather than a boolean
+  return apiCanAddNewPanel(parentApi) ? (parentApi as CanAddNewPanel) : undefined;
+};
+
+export const registerCreateSavedSearchAction = (discoverServices: DiscoverServices) => {
+  discoverServices.uiActions.registerAction<EmbeddableApiContext>({
+    id: ADD_SEARCH_EMBEDDABLE_ACTION_ID,
+    getIconType: () => 'discoverApp',
+    isCompatible: async ({ embeddable: parentApi }) => {
+      return Boolean(await parentApiIsCompatible(parentApi));
+    },
+    execute: async ({ embeddable: parentApi }) => {
+      const canAddNewPanelParent = await parentApiIsCompatible(parentApi);
+      if (!canAddNewPanelParent) throw new IncompatibleActionError();
+      const { openSavedSearchEditFlyout } = await import(
+        '../components/editor/open_saved_search_edit_flyout'
+      );
+      try {
+        const savedSearch = discoverServices.savedSearch.getNew();
+        const defaultIndexPattern = await discoverServices.data.dataViews.getDefault();
+        if (defaultIndexPattern) {
+          const queryString = getESQLWithSafeLimit(
+            `from ${defaultIndexPattern?.getIndexPattern()}`,
+            10
+          );
+          savedSearch.searchSource.setField('index', defaultIndexPattern);
+          savedSearch.searchSource.setField('query', { esql: queryString });
+        }
+        const { searchSourceJSON, references } = savedSearch.searchSource.serialize();
+
+        const embeddable = await canAddNewPanelParent.addNewPanel<SearchEmbeddableSerializedState>({
+          panelType: SEARCH_EMBEDDABLE_TYPE,
+          initialState: {
+            attributes: {
+              isTextBasedQuery: true,
+              kibanaSavedObjectMeta: {
+                searchSourceJSON,
+              },
+              references,
+            },
+          },
+        });
+
+        // open the flyout if embeddable has been created successfully
+        if (embeddable) {
+          await openSavedSearchEditFlyout({
+            isEditing: false,
+            services: discoverServices,
+            api: embeddable as SearchEmbeddableApi,
+          });
+        }
+      } catch {
+        // swallow the rejection, since this just means the user closed without saving
+      }
+    },
+    getDisplayName: () =>
+      i18n.translate('discover.embeddable.search.displayName', {
+        defaultMessage: 'Saved search',
+      }),
+  });
+
+  discoverServices.uiActions.attachAction('ADD_PANEL_TRIGGER', ADD_SEARCH_EMBEDDABLE_ACTION_ID);
+};

--- a/src/plugins/discover/public/embeddable/components/editor/open_saved_search_edit_flyout.tsx
+++ b/src/plugins/discover/public/embeddable/components/editor/open_saved_search_edit_flyout.tsx
@@ -48,6 +48,7 @@ export const openSavedSearchEditFlyout = async ({
           );
           stateManager.searchSource.next(initialSearchSource);
           stateManager.columns.next(initialState.columns);
+          api.setTimeRange(initialState.timeRange);
         }
         flyoutSession.close();
         overlayTracker?.clearOverlays();

--- a/src/plugins/discover/public/embeddable/components/editor/open_saved_search_edit_flyout.tsx
+++ b/src/plugins/discover/public/embeddable/components/editor/open_saved_search_edit_flyout.tsx
@@ -1,0 +1,116 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React, { lazy, Suspense } from 'react';
+
+import { EuiLoadingSpinner } from '@elastic/eui';
+import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
+import { tracksOverlays } from '@kbn/presentation-containers';
+import { KibanaRenderContextProvider } from '@kbn/react-kibana-context-render';
+import { toMountPoint } from '@kbn/react-kibana-mount';
+
+import { DiscoverServices } from '../../../build_services';
+import { SearchEmbeddableApi, SearchEmbeddableStateManager } from '../../types';
+import { isEsqlMode } from '../../initialize_fetch';
+
+const SavedSearchEditorFlyout = lazy(() => import('./saved_search_edit_flyout'));
+
+export const openSavedSearchEditFlyout = async ({
+  id,
+  api,
+  isEditing,
+  services,
+  stateManager,
+  navigateToEditor,
+}: {
+  id: string;
+  api: SearchEmbeddableApi;
+  isEditing: boolean;
+  services: DiscoverServices;
+  stateManager: SearchEmbeddableStateManager;
+  navigateToEditor: () => Promise<void>;
+}) => {
+  const overlayTracker = tracksOverlays(api.parentApi) ? api.parentApi : undefined;
+  // const initialState = api.snapshotRuntimeState();
+  const isEsql = isEsqlMode(api.savedSearch$.getValue());
+
+  return new Promise(async (resolve, reject) => {
+    try {
+      const onCancel = () => {
+        // Reset to initialState in case user has changed the preview state
+        // if (deepEqual(initialState, newState)) {
+        //   closeOverlay(overlay);
+        //   return;
+        // }
+
+        // if (hasChanged && fieldStatsControlsApi && initialState) {
+        //   fieldStatsControlsApi.updateUserInput(initialState);
+        // }
+
+        flyoutSession.close();
+        overlayTracker?.clearOverlays();
+      };
+
+      const onSave = async () => {
+        // const esqlQuery = nextUpdate?.query?.esql;
+        // if (isDefined(esqlQuery)) {
+        //   const indexPatternFromQuery = getIndexPatternFromESQLQuery(esqlQuery);
+        //   const dv = await getOrCreateDataViewByIndexPattern(
+        //     pluginStart.data.dataViews,
+        //     indexPatternFromQuery,
+        //     undefined
+        //   );
+        //   if (dv?.id && nextUpdate.dataViewId !== dv.id) {
+        //     nextUpdate.dataViewId = dv.id;
+        //   }
+        // }
+        // resolve(nextUpdate);
+        // flyoutSession.close();
+        // overlayTracker?.clearOverlays();
+      };
+
+      const flyoutSession = services.core.overlays.openFlyout(
+        toMountPoint(
+          <KibanaRenderContextProvider {...services}>
+            <KibanaContextProvider services={services}>
+              <Suspense fallback={<EuiLoadingSpinner />}>
+                <SavedSearchEditorFlyout
+                  api={api}
+                  isEsql={isEsql}
+                  onSave={onSave}
+                  onCancel={onCancel}
+                  services={services}
+                  isEditing={isEditing}
+                  stateManager={stateManager}
+                  navigateToEditor={navigateToEditor}
+                />
+              </Suspense>
+            </KibanaContextProvider>
+          </KibanaRenderContextProvider>,
+          services.core
+        ),
+        {
+          ownFocus: true,
+          size: 's',
+          type: 'push',
+          'data-test-subj': 'fieldStatisticsInitializerFlyout',
+          onClose: onCancel,
+          paddingSize: 'm',
+          hideCloseButton: true,
+          className: 'lnsConfigPanel__overlay savedSearchFlyout',
+        }
+      );
+
+      if (tracksOverlays(api.parentApi)) {
+        api.parentApi.openOverlay(flyoutSession, { focusedPanelId: id });
+      }
+    } catch (error) {
+      reject(error);
+    }
+  });
+};

--- a/src/plugins/discover/public/embeddable/components/editor/open_saved_search_edit_flyout.tsx
+++ b/src/plugins/discover/public/embeddable/components/editor/open_saved_search_edit_flyout.tsx
@@ -32,45 +32,30 @@ export const openSavedSearchEditFlyout = async ({
   navigateToEditor?: () => Promise<void>;
 }) => {
   const overlayTracker = tracksOverlays(api.parentApi) ? api.parentApi : undefined;
-  // const initialState = api.snapshotRuntimeState();
+  const initialState = api.snapshotRuntimeState();
   const isEsql = isEsqlMode(api.savedSearch$.getValue());
 
   return new Promise(async (resolve, reject) => {
     try {
-      const onCancel = () => {
+      const onCancel = async () => {
         if (!isEditing && apiIsPresentationContainer(api.parentApi)) {
           api.parentApi.removePanel(api.uuid);
+        } else {
+          // Reset to initialState
+          const stateManager = api.getStateManager();
+          const initialSearchSource = await services.data.search.searchSource.create(
+            initialState.serializedSearchSource
+          );
+          stateManager.searchSource.next(initialSearchSource);
+          stateManager.columns.next(initialState.columns);
         }
-        // Reset to initialState in case user has changed the preview state
-        // if (deepEqual(initialState, newState)) {
-        //   closeOverlay(overlay);
-        //   return;
-        // }
-
-        // if (hasChanged && fieldStatsControlsApi && initialState) {
-        //   fieldStatsControlsApi.updateUserInput(initialState);
-        // }
-
         flyoutSession.close();
         overlayTracker?.clearOverlays();
       };
 
       const onSave = async () => {
-        // const esqlQuery = nextUpdate?.query?.esql;
-        // if (isDefined(esqlQuery)) {
-        //   const indexPatternFromQuery = getIndexPatternFromESQLQuery(esqlQuery);
-        //   const dv = await getOrCreateDataViewByIndexPattern(
-        //     pluginStart.data.dataViews,
-        //     indexPatternFromQuery,
-        //     undefined
-        //   );
-        //   if (dv?.id && nextUpdate.dataViewId !== dv.id) {
-        //     nextUpdate.dataViewId = dv.id;
-        //   }
-        // }
-        // resolve(nextUpdate);
-        // flyoutSession.close();
-        // overlayTracker?.clearOverlays();
+        flyoutSession.close();
+        overlayTracker?.clearOverlays();
       };
 
       const flyoutSession = services.core.overlays.openFlyout(

--- a/src/plugins/discover/public/embeddable/components/editor/open_saved_search_edit_flyout.tsx
+++ b/src/plugins/discover/public/embeddable/components/editor/open_saved_search_edit_flyout.tsx
@@ -87,6 +87,7 @@ export const openSavedSearchEditFlyout = async ({
           onClose: onCancel,
           paddingSize: 'm',
           hideCloseButton: true,
+          pushMinBreakpoint: 'xs', // TODO: Better handling of overlay mode
           className: 'lnsConfigPanel__overlay savedSearchFlyout',
         }
       );

--- a/src/plugins/discover/public/embeddable/components/editor/saved_search_dataview_editor.tsx
+++ b/src/plugins/discover/public/embeddable/components/editor/saved_search_dataview_editor.tsx
@@ -1,0 +1,140 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+
+import { EuiPanel, EuiSpacer } from '@elastic/eui';
+import { DataViewListItem } from '@kbn/data-views-plugin/common';
+import { i18n } from '@kbn/i18n';
+import {
+  PublishesDataViews,
+  useBatchedOptionalPublishingSubjects,
+  useBatchedPublishingSubjects,
+} from '@kbn/presentation-publishing';
+import { DataView } from '@kbn/data-views-plugin/common';
+import { LazyDataViewPicker, withSuspense } from '@kbn/presentation-util-plugin/public';
+import {
+  UnifiedFieldListSidebarContainer,
+  type UnifiedFieldListSidebarContainerProps,
+} from '@kbn/unified-field-list';
+
+import { DiscoverServices } from '../../../build_services';
+import { SearchEmbeddableApi, SearchEmbeddableStateManager } from '../../types';
+import useAsync from 'react-use/lib/useAsync';
+
+const DataViewPicker = withSuspense(LazyDataViewPicker, null);
+
+const getCreationOptions: UnifiedFieldListSidebarContainerProps['getCreationOptions'] = () => {
+  return {
+    originatingApp: '', // TODO
+    localStorageKeyPrefix: 'savedSearch',
+    compressed: true,
+    showSidebarToggleButton: false,
+    // disableFieldListItemDragAndDrop: true,
+  };
+};
+
+export function SavedSearchDataviewEditor({
+  api,
+  stateManager,
+  services,
+}: {
+  api: SearchEmbeddableApi;
+  stateManager: SearchEmbeddableStateManager;
+  services: DiscoverServices;
+}) {
+  const initialState = useRef({
+    columns: stateManager.columns.getValue(),
+    dataViewId: stateManager.dataViewId.getValue(),
+  });
+  const [selectedDataViewId, columns] = useBatchedPublishingSubjects(
+    stateManager.dataViewId,
+    stateManager.columns
+  );
+  const [dataViews, setDataViews] = useState<DataViewListItem[]>([]);
+  const [selectedDataView, setSelectedDataView] = useState<DataView | undefined>(undefined);
+
+  useEffect(() => {
+    let mounted = true;
+    const fetchDataViews = async () => {
+      const dataViewListItems = await services.data.dataViews.getIdsWithTitle();
+      if (mounted) setDataViews(dataViewListItems);
+    };
+    fetchDataViews();
+    return () => {
+      mounted = false;
+    };
+  }, [services.data.dataViews]);
+
+  useEffect(() => {
+    let mounted = true;
+    const fetchDataView = async () => {
+      if (!selectedDataViewId) return;
+      const dataView = await services.data.dataViews.get(selectedDataViewId);
+      if (mounted) {
+        setSelectedDataView(dataView);
+        stateManager.dataViews.next([dataView]);
+      }
+    };
+    fetchDataView();
+    return () => {
+      mounted = false;
+    };
+  }, [selectedDataViewId, services.data.dataViews, stateManager.dataViews, stateManager.columns]);
+
+  return (
+    <>
+      <EuiPanel className="editorPanel" paddingSize="s">
+        <DataViewPicker
+          dataViews={dataViews ?? []}
+          selectedDataViewId={selectedDataViewId}
+          onChangeDataViewId={(nextSelection) => {
+            stateManager.dataViewId.next(nextSelection);
+            if (nextSelection === initialState.current.dataViewId) {
+              stateManager.columns.next(initialState.current.columns);
+            } else {
+              stateManager.columns.next([]);
+            }
+          }}
+          trigger={{
+            label:
+              selectedDataView?.getName() ??
+              i18n.translate('embeddableExamples.unifiedFieldList.selectDataViewMessage', {
+                defaultMessage: 'Please select a data view',
+              }),
+          }}
+        />
+
+        {selectedDataView ? (
+          <UnifiedFieldListSidebarContainer
+            fullWidth
+            variant="responsive"
+            dataView={selectedDataView}
+            showFieldList={true}
+            allFields={selectedDataView.fields}
+            getCreationOptions={getCreationOptions}
+            workspaceSelectedFieldNames={columns}
+            services={services}
+            onAddFieldToWorkspace={(field) =>
+              stateManager.columns.next([...(columns ?? []), field.name])
+            }
+            onRemoveFieldFromWorkspace={(field) => {
+              stateManager.columns.next((columns ?? []).filter((name) => name !== field.name));
+            }}
+          />
+        ) : (
+          <>error</>
+        )}
+      </EuiPanel>
+      {/* <EuiSpacer size="m" /> */}
+      {/* <EuiPanel className="editorPanel" paddingSize="s">
+        test
+      </EuiPanel> */}
+    </>
+  );
+}

--- a/src/plugins/discover/public/embeddable/components/editor/saved_search_edit_flyout.scss
+++ b/src/plugins/discover/public/embeddable/components/editor/saved_search_edit_flyout.scss
@@ -1,8 +1,11 @@
-
 .savedSearchFlyout {  
   .euiFlyoutBody {
     >* {
       pointer-events: auto;
+    }
+
+    .esqlEditor {
+      margin: (-$euiSizeS * 2) (-$euiSizeS * 2) 0 ;
     }
 
     .editorPanel {
@@ -19,11 +22,11 @@
       padding-left: 0px !important;
       padding-right: 0px !important;
     }
-  
+
     .unifiedFieldList__fieldListGrouped {
       margin-left: -8px !important;
     }
-  
+
     .unifiedFieldList__fieldListGrouped__container {
       padding-top: $euiSizeS;
       left: 0;

--- a/src/plugins/discover/public/embeddable/components/editor/saved_search_edit_flyout.tsx
+++ b/src/plugins/discover/public/embeddable/components/editor/saved_search_edit_flyout.tsx
@@ -89,9 +89,9 @@ export default function SavedSearchEditorFlyout({
       </EuiFlyoutHeader>
       <EuiFlyoutBody>
         {isEsql ? (
-          <SavedSearchEsqlEditor api={api} stateManager={stateManager} services={services} />
+          <SavedSearchEsqlEditor api={api} stateManager={stateManager} />
         ) : (
-          <SavedSearchDataviewEditor api={api} stateManager={stateManager} services={services} />
+          <SavedSearchDataviewEditor api={api} stateManager={stateManager} />
         )}
       </EuiFlyoutBody>
       <EuiFlyoutFooter>

--- a/src/plugins/discover/public/embeddable/components/editor/saved_search_edit_flyout.tsx
+++ b/src/plugins/discover/public/embeddable/components/editor/saved_search_edit_flyout.tsx
@@ -25,9 +25,9 @@ import { euiThemeVars } from '@kbn/ui-theme';
 
 import { DiscoverServices } from '../../../build_services';
 import { SearchEmbeddableApi, SearchEmbeddableStateManager } from '../../types';
-import { SavedSearchDataviewEditor } from './saved_search_dataview_editor';
-
-import './saved_search_editor_flyout.scss';
+import { SavedSearchDataviewEditor } from './saved_search_editor_dataview';
+import { SavedSearchEsqlEditor } from './saved_search_editor_esql';
+import './saved_search_edit_flyout.scss';
 
 // eslint-disable-next-line import/no-default-export
 export default function SavedSearchEditorFlyout({
@@ -43,7 +43,7 @@ export default function SavedSearchEditorFlyout({
   api: SearchEmbeddableApi;
   isEsql: boolean;
   isEditing: boolean;
-  navigateToEditor: () => Promise<void>;
+  navigateToEditor?: () => Promise<void>;
   onCancel: () => void;
   onSave: () => Promise<void>;
   stateManager: SearchEmbeddableStateManager;
@@ -76,18 +76,20 @@ export default function SavedSearchEditorFlyout({
             </EuiTitle>
           </EuiFlexItem>
 
-          <EuiFlexItem grow={false}>
-            <EuiLink onClick={navigateToEditor}>
-              {i18n.translate('discover.embeddable.search.editor.editLinkLabel', {
-                defaultMessage: 'Edit in Discover',
-              })}
-            </EuiLink>
-          </EuiFlexItem>
+          {navigateToEditor && (
+            <EuiFlexItem grow={false}>
+              <EuiLink onClick={navigateToEditor}>
+                {i18n.translate('discover.embeddable.search.editor.editLinkLabel', {
+                  defaultMessage: 'Edit in Discover',
+                })}
+              </EuiLink>
+            </EuiFlexItem>
+          )}
         </EuiFlexGroup>
       </EuiFlyoutHeader>
       <EuiFlyoutBody>
         {isEsql ? (
-          <>body</>
+          <SavedSearchEsqlEditor api={api} stateManager={stateManager} services={services} />
         ) : (
           <SavedSearchDataviewEditor api={api} stateManager={stateManager} services={services} />
         )}

--- a/src/plugins/discover/public/embeddable/components/editor/saved_search_edit_flyout.tsx
+++ b/src/plugins/discover/public/embeddable/components/editor/saved_search_edit_flyout.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 
 import {
   EuiButton,
@@ -44,11 +44,13 @@ export default function SavedSearchEditorFlyout({
   isEsql: boolean;
   isEditing: boolean;
   navigateToEditor?: () => Promise<void>;
-  onCancel: () => void;
+  onCancel: () => Promise<void>;
   onSave: () => Promise<void>;
   stateManager: SearchEmbeddableStateManager;
   services: DiscoverServices;
 }) {
+  const [isValid, setIsValid] = useState<boolean>(true);
+
   return (
     <>
       <EuiFlyoutHeader
@@ -66,11 +68,9 @@ export default function SavedSearchEditorFlyout({
                 {isEditing
                   ? i18n.translate('discover.embeddable.search.editor.editLabel', {
                       defaultMessage: 'Edit saved search',
-                      // values: { lang: language },
                     })
                   : i18n.translate('discover.embeddable.search.editor.createLabel', {
                       defaultMessage: 'Create saved search',
-                      // values: { lang: language },
                     })}
               </h2>
             </EuiTitle>
@@ -89,7 +89,7 @@ export default function SavedSearchEditorFlyout({
       </EuiFlyoutHeader>
       <EuiFlyoutBody>
         {isEsql ? (
-          <SavedSearchEsqlEditor api={api} stateManager={stateManager} />
+          <SavedSearchEsqlEditor api={api} stateManager={stateManager} setIsValid={setIsValid} />
         ) : (
           <SavedSearchDataviewEditor api={api} stateManager={stateManager} />
         )}
@@ -120,7 +120,7 @@ export default function SavedSearchEditorFlyout({
               aria-label={i18n.translate('discover.embeddable.search.editor.applyFlyoutAriaLabel', {
                 defaultMessage: 'Apply changes',
               })}
-              disabled={Boolean(isEditing) ? true : false} // TODO: Handle validation when creating
+              disabled={isEsql ? !isValid : false}
               iconType="check"
             >
               {i18n.translate('discover.embeddable.search.editor.applyFlyoutLabel', {

--- a/src/plugins/discover/public/embeddable/components/editor/saved_search_edit_flyout.tsx
+++ b/src/plugins/discover/public/embeddable/components/editor/saved_search_edit_flyout.tsx
@@ -1,0 +1,133 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+
+import {
+  EuiButton,
+  EuiButtonEmpty,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFlyoutBody,
+  EuiFlyoutFooter,
+  EuiFlyoutHeader,
+  EuiLink,
+  EuiTitle,
+} from '@elastic/eui';
+import { css } from '@emotion/react';
+import { i18n } from '@kbn/i18n';
+import { euiThemeVars } from '@kbn/ui-theme';
+
+import { DiscoverServices } from '../../../build_services';
+import { SearchEmbeddableApi, SearchEmbeddableStateManager } from '../../types';
+import { SavedSearchDataviewEditor } from './saved_search_dataview_editor';
+
+import './saved_search_editor_flyout.scss';
+
+// eslint-disable-next-line import/no-default-export
+export default function SavedSearchEditorFlyout({
+  api,
+  isEsql,
+  isEditing,
+  navigateToEditor,
+  onCancel,
+  onSave,
+  stateManager,
+  services,
+}: {
+  api: SearchEmbeddableApi;
+  isEsql: boolean;
+  isEditing: boolean;
+  navigateToEditor: () => Promise<void>;
+  onCancel: () => void;
+  onSave: () => Promise<void>;
+  stateManager: SearchEmbeddableStateManager;
+  services: DiscoverServices;
+}) {
+  return (
+    <>
+      <EuiFlyoutHeader
+        hasBorder
+        css={css`
+          pointer-events: auto;
+          background-color: ${euiThemeVars.euiColorEmptyShade};
+        `}
+        data-test-subj="editFlyoutHeader"
+      >
+        <EuiFlexGroup justifyContent="spaceBetween" alignItems="center" responsive={false}>
+          <EuiFlexItem grow={false}>
+            <EuiTitle size="xs" data-test-subj="inlineEditingFlyoutLabel">
+              <h2>
+                {isEditing
+                  ? i18n.translate('discover.embeddable.search.editor.editLabel', {
+                      defaultMessage: 'Edit saved search',
+                      // values: { lang: language },
+                    })
+                  : i18n.translate('discover.embeddable.search.editor.createLabel', {
+                      defaultMessage: 'Create saved search',
+                      // values: { lang: language },
+                    })}
+              </h2>
+            </EuiTitle>
+          </EuiFlexItem>
+
+          <EuiFlexItem grow={false}>
+            <EuiLink onClick={navigateToEditor}>
+              {i18n.translate('discover.embeddable.search.editor.editLinkLabel', {
+                defaultMessage: 'Edit in Discover',
+              })}
+            </EuiLink>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlyoutHeader>
+      <EuiFlyoutBody>
+        {isEsql ? (
+          <>body</>
+        ) : (
+          <SavedSearchDataviewEditor api={api} stateManager={stateManager} services={services} />
+        )}
+      </EuiFlyoutBody>
+      <EuiFlyoutFooter>
+        <EuiFlexGroup justifyContent="spaceBetween">
+          <EuiFlexItem grow={false}>
+            <EuiButtonEmpty
+              id="lnsCancelEditOnFlyFlyout"
+              onClick={onCancel}
+              flush="left"
+              aria-label={i18n.translate(
+                'discover.embeddable.search.editor.cancelFlyoutAriaLabel',
+                {
+                  defaultMessage: 'Cancel applied changes',
+                }
+              )}
+            >
+              {i18n.translate('discover.embeddable.search.editor.cancelFlyoutLabel', {
+                defaultMessage: 'Cancel',
+              })}
+            </EuiButtonEmpty>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiButton
+              onClick={onSave}
+              fill
+              aria-label={i18n.translate('discover.embeddable.search.editor.applyFlyoutAriaLabel', {
+                defaultMessage: 'Apply changes',
+              })}
+              disabled={Boolean(isEditing) ? true : false} // TODO: Handle validation when creating
+              iconType="check"
+            >
+              {i18n.translate('discover.embeddable.search.editor.applyFlyoutLabel', {
+                defaultMessage: 'Apply and close',
+              })}
+            </EuiButton>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlyoutFooter>
+    </>
+  );
+}

--- a/src/plugins/discover/public/embeddable/components/editor/saved_search_editor_dataview.tsx
+++ b/src/plugins/discover/public/embeddable/components/editor/saved_search_editor_dataview.tsx
@@ -57,7 +57,7 @@ export function SavedSearchDataviewEditor({
   const [dataViews, setDataViews] = useState<DataViewListItem[]>([]);
 
   useEffect(() => {
-    (api.parentApi as DashboardContainer).ignoreDashboardUnsavedChanges = true;
+    (api.parentApi as DashboardContainer).ignoreUnifiedSearch = true;
 
     const originalQuery = services.data.query.queryString.getQuery();
     services.data.query.queryString.setQuery(savedSearch.searchSource.getField('query') as Query);
@@ -84,7 +84,7 @@ export function SavedSearchDataviewEditor({
       services.data.query.queryString.setQuery(originalQuery);
       services.filterManager.setFilters(originalFilters);
 
-      (api.parentApi as DashboardContainer).ignoreDashboardUnsavedChanges = false;
+      (api.parentApi as DashboardContainer).ignoreUnifiedSearch = false;
       querySubscription.unsubscribe();
       filtersSubscription.unsubscribe();
     };

--- a/src/plugins/discover/public/embeddable/components/editor/saved_search_editor_dataview.tsx
+++ b/src/plugins/discover/public/embeddable/components/editor/saved_search_editor_dataview.tsx
@@ -58,6 +58,7 @@ export function SavedSearchDataviewEditor({
 
   useEffect(() => {
     (api.parentApi as DashboardContainer).ignoreUnifiedSearch = true;
+    (api.parentApi as DashboardContainer).dispatch.setDisableAutoRefresh(true);
 
     /** Handle query */
     const originalQuery = services.data.query.queryString.getQuery();
@@ -103,6 +104,7 @@ export function SavedSearchDataviewEditor({
       services.timefilter.setTime(originalTime);
 
       (api.parentApi as DashboardContainer).ignoreUnifiedSearch = false;
+      (api.parentApi as DashboardContainer).dispatch.setDisableAutoRefresh(false);
       querySubscription.unsubscribe();
       filtersSubscription.unsubscribe();
       timeRangeSubscription.unsubscribe();

--- a/src/plugins/discover/public/embeddable/components/editor/saved_search_editor_dataview.tsx
+++ b/src/plugins/discover/public/embeddable/components/editor/saved_search_editor_dataview.tsx
@@ -6,17 +6,12 @@
  * Side Public License, v 1.
  */
 
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
-import { EuiPanel, EuiSpacer } from '@elastic/eui';
-import { DataViewListItem } from '@kbn/data-views-plugin/common';
+import { EuiPanel } from '@elastic/eui';
+import { DataView, DataViewListItem } from '@kbn/data-views-plugin/common';
 import { i18n } from '@kbn/i18n';
-import {
-  PublishesDataViews,
-  useBatchedOptionalPublishingSubjects,
-  useBatchedPublishingSubjects,
-} from '@kbn/presentation-publishing';
-import { DataView } from '@kbn/data-views-plugin/common';
+import { useBatchedPublishingSubjects } from '@kbn/presentation-publishing';
 import { LazyDataViewPicker, withSuspense } from '@kbn/presentation-util-plugin/public';
 import {
   UnifiedFieldListSidebarContainer,
@@ -25,7 +20,6 @@ import {
 
 import { DiscoverServices } from '../../../build_services';
 import { SearchEmbeddableApi, SearchEmbeddableStateManager } from '../../types';
-import useAsync from 'react-use/lib/useAsync';
 
 const DataViewPicker = withSuspense(LazyDataViewPicker, null);
 

--- a/src/plugins/discover/public/embeddable/components/editor/saved_search_editor_dataview.tsx
+++ b/src/plugins/discover/public/embeddable/components/editor/saved_search_editor_dataview.tsx
@@ -62,7 +62,9 @@ export function SavedSearchDataviewEditor({
 
     /** Handle query */
     const originalQuery = services.data.query.queryString.getQuery();
-    services.data.query.queryString.setQuery(savedSearch.searchSource.getField('query') as Query);
+    services.data.query.queryString.setQuery(
+      savedSearch.searchSource.getOwnField('query') as Query
+    );
     const querySubscription = services.data.query.queryString
       .getUpdates$()
       .pipe(debounceTime(1))
@@ -72,7 +74,7 @@ export function SavedSearchDataviewEditor({
 
     /** Handle filters */
     const originalFilters = services.filterManager.getFilters();
-    const customFilters = (savedSearch.searchSource.getField('filter') ?? []) as Filter[];
+    const customFilters = (savedSearch.searchSource.getOwnField('filter') ?? []) as Filter[];
     if (customFilters.length > 0) {
       services.filterManager.setFilters(customFilters);
     }

--- a/src/plugins/discover/public/embeddable/components/editor/saved_search_editor_dataview.tsx
+++ b/src/plugins/discover/public/embeddable/components/editor/saved_search_editor_dataview.tsx
@@ -7,6 +7,7 @@
  */
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
+import deepEqual from 'react-fast-compare';
 import { debounceTime } from 'rxjs';
 
 import { EuiPanel } from '@elastic/eui';
@@ -97,7 +98,7 @@ export function SavedSearchDataviewEditor({
       .pipe(debounceTime(1))
       .subscribe(() => {
         const newTimeRange = services.timefilter.getTime();
-        api.setTimeRange(newTimeRange);
+        api.setTimeRange(deepEqual(originalTime, newTimeRange) ? undefined : newTimeRange);
       });
 
     return () => {

--- a/src/plugins/discover/public/embeddable/components/editor/saved_search_editor_esql.tsx
+++ b/src/plugins/discover/public/embeddable/components/editor/saved_search_editor_esql.tsx
@@ -21,6 +21,7 @@ import {
 
 import { useDiscoverServices } from '../../../hooks/use_discover_services';
 import { SearchEmbeddableApi, SearchEmbeddableStateManager } from '../../types';
+import { getEsqlQueryFieldList } from '../../../application/main/components/sidebar/lib/get_field_list';
 
 const getCreationOptions: UnifiedFieldListSidebarContainerProps['getCreationOptions'] = () => {
   return {
@@ -43,7 +44,11 @@ export function SavedSearchEsqlEditor({
 }) {
   const services = useDiscoverServices();
 
-  const [savedSearch, loading] = useBatchedPublishingSubjects(api.savedSearch$, api.dataLoading);
+  const [savedSearch, loading, esqlQueryColumns] = useBatchedPublishingSubjects(
+    api.savedSearch$,
+    api.dataLoading,
+    stateManager.esqlQueryColumns
+  );
   const [query, setQuery] = useState<AggregateQuery>(
     savedSearch.searchSource.getField('query') as AggregateQuery
   );
@@ -139,7 +144,7 @@ export function SavedSearchEsqlEditor({
             variant="responsive"
             dataView={dataView}
             showFieldList={true}
-            allFields={dataView.fields}
+            allFields={getEsqlQueryFieldList(esqlQueryColumns)}
             getCreationOptions={getCreationOptions}
             workspaceSelectedFieldNames={savedSearch.columns}
             services={services}

--- a/src/plugins/discover/public/embeddable/components/editor/saved_search_editor_esql.tsx
+++ b/src/plugins/discover/public/embeddable/components/editor/saved_search_editor_esql.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 
 import { useBatchedPublishingSubjects } from '@kbn/presentation-publishing';
 import {
@@ -15,7 +15,7 @@ import {
 } from '@kbn/unified-field-list';
 
 import { EuiPanel, EuiSpacer } from '@elastic/eui';
-import { AggregateQuery } from '@kbn/es-query';
+import { AggregateQuery, isOfAggregateQueryType } from '@kbn/es-query';
 import { TextBasedLangEditor } from '@kbn/text-based-languages/public';
 import { useDiscoverServices } from '../../../hooks/use_discover_services';
 import { SearchEmbeddableApi, SearchEmbeddableStateManager } from '../../types';
@@ -55,11 +55,7 @@ export function SavedSearchEsqlEditor({
     async (q) => {
       if (q) {
         stateManager.searchSource.next(savedSearch.searchSource.setField('query', q));
-        if (q.esql === '') {
-          setIsValid(false);
-        } else {
-          setIsValid(true);
-        }
+        setIsValid(isOfAggregateQueryType(q) && q.esql !== '');
       }
     },
     [savedSearch.searchSource, stateManager.searchSource, setIsValid]

--- a/src/plugins/discover/public/embeddable/components/editor/saved_search_editor_esql.tsx
+++ b/src/plugins/discover/public/embeddable/components/editor/saved_search_editor_esql.tsx
@@ -52,6 +52,7 @@ export function SavedSearchEsqlEditor({
   useEffect(() => {
     (api.parentApi as DashboardContainer).ignoreUnifiedSearch = true;
     (api.parentApi as DashboardContainer).dispatch.setDisableQueryInput(true);
+    (api.parentApi as DashboardContainer).dispatch.setDisableAutoRefresh(true);
 
     /** Handle filters */
     const originalFilters = services.filterManager.getFilters();
@@ -82,12 +83,12 @@ export function SavedSearchEsqlEditor({
       });
 
     return () => {
-      (api.parentApi as DashboardContainer).dispatch.setDisableQueryInput(false);
-
       services.filterManager.setFilters(originalFilters);
       services.timefilter.setTime(originalTime);
 
       (api.parentApi as DashboardContainer).ignoreUnifiedSearch = false;
+      (api.parentApi as DashboardContainer).dispatch.setDisableQueryInput(false);
+      (api.parentApi as DashboardContainer).dispatch.setDisableAutoRefresh(false);
       filtersSubscription.unsubscribe();
       timeRangeSubscription.unsubscribe();
     };

--- a/src/plugins/discover/public/embeddable/components/editor/saved_search_editor_esql.tsx
+++ b/src/plugins/discover/public/embeddable/components/editor/saved_search_editor_esql.tsx
@@ -1,0 +1,110 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+
+import { useBatchedPublishingSubjects } from '@kbn/presentation-publishing';
+import { LazyDataViewPicker, withSuspense } from '@kbn/presentation-util-plugin/public';
+import {
+  UnifiedFieldListSidebarContainer,
+  type UnifiedFieldListSidebarContainerProps,
+} from '@kbn/unified-field-list';
+
+import { AggregateQuery } from '@kbn/es-query';
+import { TextBasedLangEditor } from '@kbn/text-based-languages/public';
+import { DiscoverServices } from '../../../build_services';
+import { SearchEmbeddableApi, SearchEmbeddableStateManager } from '../../types';
+import { EuiPanel, EuiSpacer } from '@elastic/eui';
+
+const DataViewPicker = withSuspense(LazyDataViewPicker, null);
+
+const getCreationOptions: UnifiedFieldListSidebarContainerProps['getCreationOptions'] = () => {
+  return {
+    originatingApp: '', // TODO
+    localStorageKeyPrefix: 'savedSearch',
+    compressed: true,
+    showSidebarToggleButton: false,
+    // disableFieldListItemDragAndDrop: true,
+  };
+};
+
+export function SavedSearchEsqlEditor({
+  api,
+  stateManager,
+  services,
+}: {
+  api: SearchEmbeddableApi;
+  stateManager: SearchEmbeddableStateManager;
+  services: DiscoverServices;
+}) {
+  const [dataView, columns, searchSource, loading] = useBatchedPublishingSubjects(
+    stateManager.dataView,
+    stateManager.columns,
+    stateManager.searchSource,
+    api.dataLoading
+  );
+  const [query, setQuery] = useState<AggregateQuery>(
+    searchSource.getField('query') as AggregateQuery
+  );
+  const prevQuery = useRef<AggregateQuery>(query);
+
+  const onTextLangQuerySubmit = useCallback(
+    async (q) => {
+      if (q) {
+        stateManager.searchSource.next(searchSource.setField('query', q));
+      }
+    },
+    [searchSource, stateManager.searchSource]
+  );
+
+  return (
+    <>
+      {query && (
+        <div className="esqlEditor">
+          <TextBasedLangEditor
+            query={query}
+            onTextLangQueryChange={(q) => {
+              setQuery(q);
+              prevQuery.current = q;
+            }}
+            expandCodeEditor={(status: boolean) => {}}
+            isCodeEditorExpanded
+            hideMinimizeButton
+            editorIsInline
+            hideRunQueryText
+            onTextLangQuerySubmit={onTextLangQuerySubmit}
+            isDisabled={false}
+            allowQueryCancellation
+            isLoading={loading}
+          />
+        </div>
+      )}
+      <EuiSpacer size="m" />
+      {dataView && (
+        <EuiPanel className="editorPanel" paddingSize="s">
+          <UnifiedFieldListSidebarContainer
+            fullWidth
+            variant="responsive"
+            dataView={dataView}
+            showFieldList={true}
+            allFields={dataView.fields}
+            getCreationOptions={getCreationOptions}
+            workspaceSelectedFieldNames={columns}
+            services={services}
+            onAddFieldToWorkspace={(field) =>
+              stateManager.columns.next([...(columns ?? []), field.name])
+            }
+            onRemoveFieldFromWorkspace={(field) => {
+              stateManager.columns.next((columns ?? []).filter((name) => name !== field.name));
+            }}
+          />
+        </EuiPanel>
+      )}
+    </>
+  );
+}

--- a/src/plugins/discover/public/embeddable/components/editor/saved_search_editor_esql.tsx
+++ b/src/plugins/discover/public/embeddable/components/editor/saved_search_editor_esql.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React, { useCallback, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { useBatchedPublishingSubjects } from '@kbn/presentation-publishing';
 import {
@@ -33,9 +33,11 @@ const getCreationOptions: UnifiedFieldListSidebarContainerProps['getCreationOpti
 export function SavedSearchEsqlEditor({
   api,
   stateManager,
+  setIsValid,
 }: {
   api: SearchEmbeddableApi;
   stateManager: SearchEmbeddableStateManager;
+  setIsValid: (valid: boolean) => void;
 }) {
   const services = useDiscoverServices();
 
@@ -44,15 +46,23 @@ export function SavedSearchEsqlEditor({
     savedSearch.searchSource.getField('query') as AggregateQuery
   );
   const prevQuery = useRef<AggregateQuery>(query);
-  const dataView = savedSearch.searchSource.getField('index');
+
+  const dataView = useMemo(() => {
+    return savedSearch.searchSource.getField('index');
+  }, [savedSearch]);
 
   const onTextLangQuerySubmit = useCallback(
     async (q) => {
       if (q) {
         stateManager.searchSource.next(savedSearch.searchSource.setField('query', q));
+        if (q.esql === '') {
+          setIsValid(false);
+        } else {
+          setIsValid(true);
+        }
       }
     },
-    [savedSearch.searchSource, stateManager.searchSource]
+    [savedSearch.searchSource, stateManager.searchSource, setIsValid]
   );
 
   return (

--- a/src/plugins/discover/public/embeddable/components/editor/saved_search_editor_esql.tsx
+++ b/src/plugins/discover/public/embeddable/components/editor/saved_search_editor_esql.tsx
@@ -6,17 +6,18 @@
  * Side Public License, v 1.
  */
 
-import React, { useCallback, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
+import { EuiPanel, EuiSpacer } from '@elastic/eui';
+import { DashboardContainer } from '@kbn/dashboard-plugin/public/dashboard_container';
+import { AggregateQuery, isOfAggregateQueryType } from '@kbn/es-query';
 import { useBatchedPublishingSubjects } from '@kbn/presentation-publishing';
+import { TextBasedLangEditor } from '@kbn/text-based-languages/public';
 import {
   UnifiedFieldListSidebarContainer,
   type UnifiedFieldListSidebarContainerProps,
 } from '@kbn/unified-field-list';
 
-import { EuiPanel, EuiSpacer } from '@elastic/eui';
-import { AggregateQuery, isOfAggregateQueryType } from '@kbn/es-query';
-import { TextBasedLangEditor } from '@kbn/text-based-languages/public';
 import { useDiscoverServices } from '../../../hooks/use_discover_services';
 import { SearchEmbeddableApi, SearchEmbeddableStateManager } from '../../types';
 
@@ -46,6 +47,14 @@ export function SavedSearchEsqlEditor({
     savedSearch.searchSource.getField('query') as AggregateQuery
   );
   const prevQuery = useRef<AggregateQuery>(query);
+
+  useEffect(() => {
+    (api.parentApi as DashboardContainer).dispatch.setDisableQueryInput(true);
+    return () => {
+      (api.parentApi as DashboardContainer).dispatch.setDisableQueryInput(false);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const dataView = useMemo(() => {
     return savedSearch.searchSource.getField('index');

--- a/src/plugins/discover/public/embeddable/components/editor/saved_search_editor_esql.tsx
+++ b/src/plugins/discover/public/embeddable/components/editor/saved_search_editor_esql.tsx
@@ -50,7 +50,7 @@ export function SavedSearchEsqlEditor({
     stateManager.esqlQueryColumns
   );
   const [query, setQuery] = useState<AggregateQuery>(
-    savedSearch.searchSource.getField('query') as AggregateQuery
+    savedSearch.searchSource.getOwnField('query') as AggregateQuery
   );
   const prevQuery = useRef<AggregateQuery>(query);
 
@@ -61,7 +61,7 @@ export function SavedSearchEsqlEditor({
 
     /** Handle filters */
     const originalFilters = services.filterManager.getFilters();
-    const customFilters = (savedSearch.searchSource.getField('filter') ?? []) as Filter[];
+    const customFilters = (savedSearch.searchSource.getOwnField('filter') ?? []) as Filter[];
     if (customFilters.length > 0) {
       services.filterManager.setFilters(customFilters);
     }

--- a/src/plugins/discover/public/embeddable/components/editor/saved_search_editor_flyout.scss
+++ b/src/plugins/discover/public/embeddable/components/editor/saved_search_editor_flyout.scss
@@ -1,0 +1,38 @@
+
+.savedSearchFlyout {  
+  .euiFlyoutBody {
+    >* {
+      pointer-events: auto;
+    }
+
+    .editorPanel {
+      overflow: auto;
+      max-height: 500px;
+    }
+  }
+
+  .unifiedFieldListSidebar__list {
+    padding-left: 0px !important;
+    padding-right: 0px !important;
+  
+    >* {
+      padding-left: 0px !important;
+      padding-right: 0px !important;
+    }
+  
+    .unifiedFieldList__fieldListGrouped {
+      margin-left: -8px !important;
+    }
+  
+    .unifiedFieldList__fieldListGrouped__container {
+      padding-top: $euiSizeS;
+      left: 0;
+      right: 0;
+      position: relative !important;
+    }
+  }
+
+  .euiFlyoutFooter {
+    border-top: $euiBorderThin;
+  }
+}

--- a/src/plugins/discover/public/embeddable/components/search_embeddable_grid_component.tsx
+++ b/src/plugins/discover/public/embeddable/components/search_embeddable_grid_component.tsx
@@ -163,7 +163,7 @@ export function SearchEmbeddableGridComponent({
       <DiscoverDocTableEmbeddableMemoized
         {...sharedProps}
         {...onStateEditedProps}
-        filters={savedSearch.searchSource.getField('filter') as Filter[]}
+        filters={savedSearch.searchSource.getOwnField('filter') as Filter[]}
         isEsqlMode={isEsql}
         isLoading={Boolean(loading)}
         sharedItemTitle={panelTitle || savedSearchTitle}
@@ -181,7 +181,7 @@ export function SearchEmbeddableGridComponent({
       headerRowHeightState={savedSearch.headerRowHeight}
       isPlainRecord={isEsql}
       loadingState={Boolean(loading) ? DataLoadingState.loading : DataLoadingState.loaded}
-      query={savedSearch.searchSource.getField('query')}
+      query={savedSearch.searchSource.getOwnField('query')}
       rowHeightState={savedSearch.rowHeight}
       savedSearchId={savedSearchId}
       searchTitle={panelTitle || savedSearchTitle}

--- a/src/plugins/discover/public/embeddable/constants.ts
+++ b/src/plugins/discover/public/embeddable/constants.ts
@@ -37,5 +37,4 @@ export const EDITABLE_SAVED_SEARCH_KEYS: Readonly<
 export const EDITABLE_PANEL_KEYS = [
   'title', // panel title
   'description', // panel description
-  'timeRange', // panel custom time range
 ] as const;

--- a/src/plugins/discover/public/embeddable/constants.ts
+++ b/src/plugins/discover/public/embeddable/constants.ts
@@ -24,14 +24,14 @@ export const SEARCH_EMBEDDABLE_CELL_ACTIONS_TRIGGER: Trigger = {
 export const DEFAULT_HEADER_ROW_HEIGHT_LINES = 3;
 
 /** This constant refers to the parts of the saved search state that can be edited from a dashboard */
-export const EDITABLE_SAVED_SEARCH_KEYS: Readonly<Array<keyof SavedSearchAttributes>> = [
-  'sort',
-  'columns',
-  'rowHeight',
-  'sampleSize',
-  'rowsPerPage',
-  'headerRowHeight',
-] as const;
+export const EDITABLE_SAVED_SEARCH_KEYS: Readonly<
+  Array<
+    keyof Pick<
+      SavedSearchAttributes,
+      'sort' | 'columns' | 'rowHeight' | 'sampleSize' | 'rowsPerPage' | 'headerRowHeight'
+    >
+  >
+> = ['sort', 'columns', 'rowHeight', 'sampleSize', 'rowsPerPage', 'headerRowHeight'] as const;
 
 /** This constant refers to the dashboard panel specific state */
 export const EDITABLE_PANEL_KEYS = [

--- a/src/plugins/discover/public/embeddable/get_search_embeddable_factory.tsx
+++ b/src/plugins/discover/public/embeddable/get_search_embeddable_factory.tsx
@@ -162,11 +162,10 @@ export const getSearchEmbeddableFactory = ({
           serializeState: async () => {
             const savedObjectId = savedObjectId$.getValue();
             const updatedSavedSearch = searchEmbeddable.api.savedSearch$.getValue();
-            console.log('timeRange.serialize()', timeRange.serialize());
             if (savedObjectId && api.unsavedChanges.getValue()) {
               // update the saved object **only** if something changed
               await save({
-                ...updatedSavedSearch,
+                ...omit(updatedSavedSearch, 'timeRange'),
                 ...timeRange.serialize(),
                 id: savedObjectId,
                 title: defaultPanelTitle$.getValue(),

--- a/src/plugins/discover/public/embeddable/get_search_embeddable_factory.tsx
+++ b/src/plugins/discover/public/embeddable/get_search_embeddable_factory.tsx
@@ -159,15 +159,27 @@ export const getSearchEmbeddableFactory = ({
             defaultPanelTitle$.next(undefined);
             defaultPanelDescription$.next(undefined);
           },
-          serializeState: () =>
-            serializeState({
+          serializeState: async () => {
+            const savedObjectId = savedObjectId$.getValue();
+            const updatedSavedSearch = searchEmbeddable.api.savedSearch$.getValue();
+            if (savedObjectId && api.unsavedChanges.getValue()) {
+              // update the saved object **only** if something changed
+              await save({
+                ...updatedSavedSearch,
+                ...timeRange.serialize(),
+                id: savedObjectId,
+                title: defaultPanelTitle$.getValue(),
+              });
+            }
+            return serializeState({
               uuid,
               initialState,
               savedSearch: searchEmbeddable.api.savedSearch$.getValue(),
               serializeTitles,
               serializeTimeRange: timeRange.serialize,
               savedObjectId: savedObjectId$.getValue(),
-            }),
+            });
+          },
         },
         {
           ...titleComparators,

--- a/src/plugins/discover/public/embeddable/get_search_embeddable_factory.tsx
+++ b/src/plugins/discover/public/embeddable/get_search_embeddable_factory.tsx
@@ -115,9 +115,10 @@ export const getSearchEmbeddableFactory = ({
           ...initializeEditApi({
             uuid,
             parentApi,
-            partialApi: { ...searchEmbeddable.api, fetchContext$, savedObjectId: savedObjectId$ },
             discoverServices,
             isEditable: startServices.isEditable,
+            stateManager: searchEmbeddable.stateManager,
+            getApi: () => ({ ...api, fetchContext$ }),
           }),
           dataLoading: dataLoading$,
           blockingError: blockingError$,

--- a/src/plugins/discover/public/embeddable/get_search_embeddable_factory.tsx
+++ b/src/plugins/discover/public/embeddable/get_search_embeddable_factory.tsx
@@ -162,6 +162,7 @@ export const getSearchEmbeddableFactory = ({
           serializeState: async () => {
             const savedObjectId = savedObjectId$.getValue();
             const updatedSavedSearch = searchEmbeddable.api.savedSearch$.getValue();
+            console.log('timeRange.serialize()', timeRange.serialize());
             if (savedObjectId && api.unsavedChanges.getValue()) {
               // update the saved object **only** if something changed
               await save({

--- a/src/plugins/discover/public/embeddable/initialize_edit_api.ts
+++ b/src/plugins/discover/public/embeddable/initialize_edit_api.ts
@@ -10,7 +10,7 @@ import { i18n } from '@kbn/i18n';
 import { apiHasAppContext, FetchContext, PublishingSubject } from '@kbn/presentation-publishing';
 import { DiscoverServices } from '../build_services';
 import { openSavedSearchEditFlyout } from './components/editor/open_saved_search_edit_flyout';
-import { SearchEmbeddableApi, SearchEmbeddableStateManager } from './types';
+import { SearchEmbeddableApi } from './types';
 import { getDiscoverLocatorParams } from './utils/get_discover_locator_params';
 
 export async function getAppTarget(api: SearchEmbeddableApi, discoverServices: DiscoverServices) {
@@ -32,19 +32,17 @@ export async function getAppTarget(api: SearchEmbeddableApi, discoverServices: D
 
 export function initializeEditApi({
   uuid,
-  parentApi,
   getApi,
+  parentApi,
   isEditable,
-  stateManager,
   discoverServices,
 }: {
   uuid: string;
-  parentApi?: unknown;
   getApi: () => SearchEmbeddableApi & {
     fetchContext$: PublishingSubject<FetchContext | undefined>;
   };
+  parentApi?: unknown;
   isEditable: () => boolean;
-  stateManager: SearchEmbeddableStateManager;
   discoverServices: DiscoverServices;
 }) {
   /**
@@ -81,9 +79,6 @@ export function initializeEditApi({
       const api = getApi();
       await openSavedSearchEditFlyout({
         api,
-        parentApi,
-        id: uuid,
-        stateManager,
         isEditing: true,
         navigateToEditor,
         services: discoverServices,

--- a/src/plugins/discover/public/embeddable/initialize_edit_api.ts
+++ b/src/plugins/discover/public/embeddable/initialize_edit_api.ts
@@ -81,6 +81,7 @@ export function initializeEditApi({
       const api = getApi();
       await openSavedSearchEditFlyout({
         api,
+        parentApi,
         id: uuid,
         stateManager,
         isEditing: true,

--- a/src/plugins/discover/public/embeddable/initialize_fetch.tsx
+++ b/src/plugins/discover/public/embeddable/initialize_fetch.tsx
@@ -46,7 +46,7 @@ type SavedSearchPrivateFetchApi = SearchEmbeddableApi & {
 };
 
 export const isEsqlMode = (savedSearch: Pick<SavedSearch, 'searchSource'>): boolean => {
-  const query = savedSearch.searchSource.getField('query');
+  const query = savedSearch.searchSource.getOwnField('query');
   return isOfAggregateQueryType(query);
 };
 
@@ -112,7 +112,7 @@ export function initializeFetch({
         );
 
         const searchSessionId = fetchContext.searchSessionId;
-        const searchSourceQuery = savedSearch.searchSource.getField('query');
+        const searchSourceQuery = savedSearch.searchSource.getOwnField('query');
 
         try {
           api.dataLoading.next(true);

--- a/src/plugins/discover/public/embeddable/initialize_fetch.tsx
+++ b/src/plugins/discover/public/embeddable/initialize_fetch.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { BehaviorSubject, combineLatest, lastValueFrom, switchMap } from 'rxjs';
+import { BehaviorSubject, combineLatest, debounceTime, lastValueFrom, switchMap } from 'rxjs';
 
 import { KibanaExecutionContext } from '@kbn/core/types';
 import {
@@ -93,10 +93,10 @@ export function initializeFetch({
   const requestAdapter = new RequestAdapter();
   let abortController = new AbortController();
 
-  const fetchSubscription = combineLatest([fetch$(api), api.savedSearch$, api.dataViews])
+  const fetchSubscription = combineLatest([fetch$(api), api.savedSearch$, stateManager.dataView])
     .pipe(
-      switchMap(async ([fetchContext, savedSearch, dataViews]) => {
-        const dataView = dataViews?.length ? dataViews[0] : undefined;
+      debounceTime(1),
+      switchMap(async ([fetchContext, savedSearch, dataView]) => {
         api.blockingError.next(undefined);
         if (!dataView || !savedSearch.searchSource) {
           return;

--- a/src/plugins/discover/public/embeddable/initialize_fetch.tsx
+++ b/src/plugins/discover/public/embeddable/initialize_fetch.tsx
@@ -155,6 +155,7 @@ export function initializeFetch({
               rows: result.records,
               hitCount: result.records.length,
               fetchContext,
+              esqlQueryColumns: result.esqlQueryColumns,
             };
           }
 
@@ -210,8 +211,13 @@ export function initializeFetch({
       stateManager.totalHitCount.next(next.hitCount);
       api.fetchWarnings$.next(next.warnings ?? []);
       api.fetchContext$.next(next.fetchContext);
+
+      /** ESQL stuff */
       if (next.hasOwnProperty('columnsMeta')) {
         stateManager.columnsMeta.next(next.columnsMeta);
+      }
+      if (next.hasOwnProperty('esqlQueryColumns')) {
+        stateManager.esqlQueryColumns.next(next.esqlQueryColumns);
       }
     });
 

--- a/src/plugins/discover/public/embeddable/initialize_search_embeddable_api.tsx
+++ b/src/plugins/discover/public/embeddable/initialize_search_embeddable_api.tsx
@@ -15,6 +15,7 @@ import { DataView } from '@kbn/data-views-plugin/common';
 import { ROW_HEIGHT_OPTION, SAMPLE_SIZE_SETTING } from '@kbn/discover-utils';
 import { DataTableRecord } from '@kbn/discover-utils/types';
 import { AggregateQuery, Filter, Query } from '@kbn/es-query';
+import { DatatableColumn } from '@kbn/expressions-plugin/common';
 import type {
   PublishesDataViews,
   PublishesUnifiedSearch,
@@ -107,6 +108,7 @@ export const initializeSearchEmbeddableApi = async (
   /** This is the state that has to be fetched */
   const rows$ = new BehaviorSubject<DataTableRecord[]>([]);
   const columnsMeta$ = new BehaviorSubject<DataTableColumnsMeta | undefined>(undefined);
+  const esqlQueryColumns$ = new BehaviorSubject<DatatableColumn[] | undefined>(undefined);
   const totalHitCount$ = new BehaviorSubject<number | undefined>(undefined);
 
   const defaultRowHeight = discoverServices.uiSettings.get(ROW_HEIGHT_OPTION);
@@ -121,6 +123,7 @@ export const initializeSearchEmbeddableApi = async (
     breakdownField: breakdownField$,
     columns: columns$,
     columnsMeta: columnsMeta$,
+    esqlQueryColumns: esqlQueryColumns$,
     headerRowHeight: headerRowHeight$,
     rows: rows$,
     rowHeight: rowHeight$,

--- a/src/plugins/discover/public/embeddable/initialize_search_embeddable_api.tsx
+++ b/src/plugins/discover/public/embeddable/initialize_search_embeddable_api.tsx
@@ -177,8 +177,8 @@ export const initializeSearchEmbeddableApi = async (
       if (newDataView) {
         newSavedSearch.searchSource.setField('index', newDataView);
       }
-      filters$.next(newSavedSearch.searchSource.getField('filter') as Filter[]);
-      query$.next(newSavedSearch.searchSource.getField('query'));
+      filters$.next(newSavedSearch.searchSource.getOwnField('filter') as Filter[]);
+      query$.next(newSavedSearch.searchSource.getOwnField('query'));
       savedSearch$.next(newSavedSearch);
     });
 

--- a/src/plugins/discover/public/embeddable/initialize_search_embeddable_api.tsx
+++ b/src/plugins/discover/public/embeddable/initialize_search_embeddable_api.tsx
@@ -114,6 +114,8 @@ export const initializeSearchEmbeddableApi = async (
     sort: sort$,
     totalHitCount: totalHitCount$,
     viewMode: savedSearchViewMode$,
+    dataViews,
+    dataViewId: new BehaviorSubject<string | undefined>(dataView?.id),
   };
 
   /** The saved search should be the source of truth for all state  */

--- a/src/plugins/discover/public/embeddable/initialize_search_embeddable_api.tsx
+++ b/src/plugins/discover/public/embeddable/initialize_search_embeddable_api.tsx
@@ -84,6 +84,8 @@ export const initializeSearchEmbeddableApi = async (
     initialState.serializedSearchSource
   );
   const searchSource$ = new BehaviorSubject<ISearchSource>(searchSource);
+
+  /** Initialize the stuff that is tied to the search source; time range comes from timeRangeApi */
   const filters$ = new BehaviorSubject<Filter[] | undefined>(
     searchSource.getField('filter') as Filter[]
   );
@@ -138,8 +140,7 @@ export const initializeSearchEmbeddableApi = async (
     pick(stateManager, EDITABLE_SAVED_SEARCH_KEYS)
   );
 
-  const parent = searchSource.getParent(); // dashboard
-
+  const searchSourceParent = searchSource.getParent(); // this should be the dashboard
   /** Keep the saved search in sync with any state changes */
   const syncSavedSearch = combineLatest([onAnyStateChange, serializedSearchSource$])
     .pipe(
@@ -152,7 +153,7 @@ export const initializeSearchEmbeddableApi = async (
           const newSearchSource = await discoverServices.data.search.searchSource.create(
             serializedSearchSource
           );
-          newSearchSource.setParent(parent);
+          newSearchSource.setParent(searchSourceParent);
           const newSavedSearch: SavedSearch = {
             ...savedSearch$.getValue(),
             ...partialSavedSearch,

--- a/src/plugins/discover/public/embeddable/types.ts
+++ b/src/plugins/discover/public/embeddable/types.ts
@@ -9,6 +9,7 @@
 import { ISearchSource } from '@kbn/data-plugin/common';
 import { DataTableRecord } from '@kbn/discover-utils/types';
 import type { DefaultEmbeddableApi } from '@kbn/embeddable-plugin/public';
+import { DatatableColumn } from '@kbn/expressions-plugin/common';
 import {
   EmbeddableApiContext,
   HasEditCapabilities,
@@ -39,6 +40,7 @@ export type SearchEmbeddableState = Pick<
   rows: DataTableRecord[];
   columnsMeta: DataTableColumnsMeta | undefined;
   totalHitCount: number | undefined;
+  esqlQueryColumns: DatatableColumn[] | undefined;
 };
 
 export type SearchEmbeddableStateManager = {
@@ -49,7 +51,7 @@ export type SearchEmbeddableStateManager = {
 
 export type SearchEmbeddableSerializedAttributes = Omit<
   SearchEmbeddableState,
-  'rows' | 'columnsMeta' | 'totalHitCount' | 'searchSource'
+  'rows' | 'columnsMeta' | 'totalHitCount' | 'searchSource' | 'esqlQueryColumns'
 > &
   Pick<SerializableSavedSearch, 'serializedSearchSource'>;
 

--- a/src/plugins/discover/public/embeddable/types.ts
+++ b/src/plugins/discover/public/embeddable/types.ts
@@ -6,6 +6,7 @@
  * Side Public License, v 1.
  */
 
+import { ISearchSource } from '@kbn/data-plugin/common';
 import { DataView } from '@kbn/data-views-plugin/common';
 import { DataTableRecord } from '@kbn/discover-utils/types';
 import type { DefaultEmbeddableApi } from '@kbn/embeddable-plugin/public';
@@ -49,8 +50,8 @@ export type SearchEmbeddableState = Pick<
 export type SearchEmbeddableStateManager = {
   [key in keyof Required<SearchEmbeddableState>]: BehaviorSubject<SearchEmbeddableState[key]>;
 } & {
-  dataViews: BehaviorSubject<DataView[] | undefined>;
-  dataViewId: BehaviorSubject<string | undefined>;
+  dataView: BehaviorSubject<DataView | undefined>;
+  searchSource: BehaviorSubject<ISearchSource>;
 };
 
 export type SearchEmbeddableSerializedAttributes = Omit<
@@ -63,7 +64,7 @@ export type SearchEmbeddableSerializedState = SerializedTitles &
   SerializedTimeRange &
   Partial<Pick<SavedSearchAttributes, typeof EDITABLE_SAVED_SEARCH_KEYS[number]>> & {
     // by value
-    attributes?: SavedSearchAttributes & { references: SavedSearch['references'] };
+    attributes?: Partial<SavedSearchAttributes> & { references: SavedSearch['references'] };
     // by reference
     savedObjectId?: string;
   };
@@ -88,7 +89,9 @@ export type SearchEmbeddableApi = DefaultEmbeddableApi<
   PublishesDataViews &
   HasInPlaceLibraryTransforms &
   HasTimeRange &
-  Partial<HasEditCapabilities & PublishesSavedObjectId>;
+  Partial<HasEditCapabilities & PublishesSavedObjectId> & {
+    getStateManager: () => SearchEmbeddableStateManager; // probably not best to expose this but makes creation easier ¯\_(ツ)_/¯
+  };
 
 export interface PublishesSavedSearch {
   savedSearch$: PublishingSubject<SavedSearch>;

--- a/src/plugins/discover/public/embeddable/types.ts
+++ b/src/plugins/discover/public/embeddable/types.ts
@@ -22,6 +22,7 @@ import {
   SerializedTimeRange,
   SerializedTitles,
 } from '@kbn/presentation-publishing';
+import { PublishesWritableTimeRange } from '@kbn/presentation-publishing/interfaces/fetch/publishes_unified_search';
 import {
   SavedSearch,
   SavedSearchAttributes,
@@ -81,6 +82,7 @@ export type SearchEmbeddableApi = DefaultEmbeddableApi<
   PublishesDataViews &
   HasInPlaceLibraryTransforms &
   HasTimeRange &
+  PublishesWritableTimeRange &
   Partial<HasEditCapabilities & PublishesSavedObjectId & PublishesUnifiedSearch> & {
     // PublishesUnifiedSearch represents the parts of the search source that should be exposed
     getStateManager: () => SearchEmbeddableStateManager; // probably not best to expose this but makes creation easier ¯\_(ツ)_/¯

--- a/src/plugins/discover/public/embeddable/types.ts
+++ b/src/plugins/discover/public/embeddable/types.ts
@@ -7,7 +7,6 @@
  */
 
 import { ISearchSource } from '@kbn/data-plugin/common';
-import { DataView } from '@kbn/data-views-plugin/common';
 import { DataTableRecord } from '@kbn/discover-utils/types';
 import type { DefaultEmbeddableApi } from '@kbn/embeddable-plugin/public';
 import {
@@ -33,14 +32,7 @@ import { EDITABLE_SAVED_SEARCH_KEYS } from './constants';
 
 export type SearchEmbeddableState = Pick<
   SerializableSavedSearch,
-  | 'rowHeight'
-  | 'rowsPerPage'
-  | 'headerRowHeight'
-  | 'columns'
-  | 'sort'
-  | 'sampleSize'
-  | 'breakdownField'
-  | 'viewMode'
+  typeof EDITABLE_SAVED_SEARCH_KEYS[number] | 'breakdownField' | 'viewMode'
 > & {
   rows: DataTableRecord[];
   columnsMeta: DataTableColumnsMeta | undefined;

--- a/src/plugins/discover/public/embeddable/types.ts
+++ b/src/plugins/discover/public/embeddable/types.ts
@@ -50,7 +50,6 @@ export type SearchEmbeddableState = Pick<
 export type SearchEmbeddableStateManager = {
   [key in keyof Required<SearchEmbeddableState>]: BehaviorSubject<SearchEmbeddableState[key]>;
 } & {
-  dataView: BehaviorSubject<DataView | undefined>;
   searchSource: BehaviorSubject<ISearchSource>;
 };
 

--- a/src/plugins/discover/public/embeddable/types.ts
+++ b/src/plugins/discover/public/embeddable/types.ts
@@ -17,6 +17,7 @@ import {
   PublishesDataLoading,
   PublishesDataViews,
   PublishesSavedObjectId,
+  PublishesUnifiedSearch,
   PublishingSubject,
   SerializedTimeRange,
   SerializedTitles,
@@ -80,7 +81,8 @@ export type SearchEmbeddableApi = DefaultEmbeddableApi<
   PublishesDataViews &
   HasInPlaceLibraryTransforms &
   HasTimeRange &
-  Partial<HasEditCapabilities & PublishesSavedObjectId> & {
+  Partial<HasEditCapabilities & PublishesSavedObjectId & PublishesUnifiedSearch> & {
+    // PublishesUnifiedSearch represents the parts of the search source that should be exposed
     getStateManager: () => SearchEmbeddableStateManager; // probably not best to expose this but makes creation easier ¯\_(ツ)_/¯
   };
 

--- a/src/plugins/discover/public/embeddable/types.ts
+++ b/src/plugins/discover/public/embeddable/types.ts
@@ -6,6 +6,7 @@
  * Side Public License, v 1.
  */
 
+import { DataView } from '@kbn/data-views-plugin/common';
 import { DataTableRecord } from '@kbn/discover-utils/types';
 import type { DefaultEmbeddableApi } from '@kbn/embeddable-plugin/public';
 import {
@@ -47,6 +48,9 @@ export type SearchEmbeddableState = Pick<
 
 export type SearchEmbeddableStateManager = {
   [key in keyof Required<SearchEmbeddableState>]: BehaviorSubject<SearchEmbeddableState[key]>;
+} & {
+  dataViews: BehaviorSubject<DataView[] | undefined>;
+  dataViewId: BehaviorSubject<string | undefined>;
 };
 
 export type SearchEmbeddableSerializedAttributes = Omit<

--- a/src/plugins/discover/public/embeddable/utils/serialization_utils.ts
+++ b/src/plugins/discover/public/embeddable/utils/serialization_utils.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { omit, pick } from 'lodash';
+import { pick } from 'lodash';
 
 import { EmbeddableStateWithType } from '@kbn/embeddable-plugin/common';
 import { SerializedPanelState } from '@kbn/presentation-containers';
@@ -20,11 +20,7 @@ import { SavedSearchUnwrapResult } from '@kbn/saved-search-plugin/public';
 
 import { extract, inject } from '../../../common/embeddable/search_inject_extract';
 import { DiscoverServices } from '../../build_services';
-import {
-  EDITABLE_PANEL_KEYS,
-  EDITABLE_SAVED_SEARCH_KEYS,
-  SEARCH_EMBEDDABLE_TYPE,
-} from '../constants';
+import { EDITABLE_PANEL_KEYS, SEARCH_EMBEDDABLE_TYPE } from '../constants';
 import { SearchEmbeddableRuntimeState, SearchEmbeddableSerializedState } from '../types';
 
 export const deserializeState = async ({
@@ -40,7 +36,6 @@ export const deserializeState = async ({
     // by reference
     const { get } = discoverServices.savedSearch;
     const so = await get(savedObjectId, true);
-    const savedObjectOverride = pick(serializedState.rawState, EDITABLE_SAVED_SEARCH_KEYS);
     return {
       ...so,
       savedObjectId,
@@ -48,7 +43,6 @@ export const deserializeState = async ({
       savedObjectDescription: so.description,
       // Overwrite SO state with dashboard state for title, description, columns, sort, etc.
       ...panelState,
-      ...savedObjectOverride,
     };
   } else {
     // by value
@@ -91,9 +85,7 @@ export const serializeState = ({
     return {
       rawState: {
         savedObjectId,
-        // Serialize the current dashboard state into the panel state **without** updating the saved object
         ...serializeTitles(),
-        ...serializeTimeRange(),
       },
       // No references to extract for by-reference embeddable since all references are stored with by-reference saved object
       references: [],

--- a/src/plugins/discover/public/embeddable/utils/serialization_utils.ts
+++ b/src/plugins/discover/public/embeddable/utils/serialization_utils.ts
@@ -59,7 +59,7 @@ export const deserializeState = async ({
       undefined,
       inject(
         serializedState.rawState as unknown as EmbeddableStateWithType,
-        serializedState.references ?? []
+        serializedState.rawState.attributes?.references ?? []
       ) as SavedSearchUnwrapResult,
       true
     );

--- a/src/plugins/discover/public/plugin.tsx
+++ b/src/plugins/discover/public/plugin.tsx
@@ -59,6 +59,7 @@ import {
   RootProfileService,
 } from './context_awareness';
 import { DiscoverSetup, DiscoverSetupPlugins, DiscoverStart, DiscoverStartPlugins } from './types';
+import { registerCreateSavedSearchAction } from './embeddable/actions/create_saved_search_action';
 
 /**
  * Contains Discover, one of the oldest parts of Kibana
@@ -285,6 +286,8 @@ export class DiscoverPlugin
     const getDiscoverServicesInternal = () => {
       return this.getDiscoverServices(core, plugins, this.createEmptyProfilesManager());
     };
+
+    registerCreateSavedSearchAction(getDiscoverServicesInternal());
 
     return {
       locator: this.locator,

--- a/src/plugins/navigation/public/top_nav_menu/top_nav_menu.tsx
+++ b/src/plugins/navigation/public/top_nav_menu/top_nav_menu.tsx
@@ -26,6 +26,7 @@ export type TopNavMenuProps<QT extends Query | AggregateQuery = Query> = Omit<
   badges?: TopNavMenuBadgeProps[];
   showSearchBar?: boolean;
   showQueryInput?: boolean;
+  disableQueryInput?: boolean;
   showDatePicker?: boolean;
   showFilterBar?: boolean;
   unifiedSearch?: UnifiedSearchPublicPluginStart;

--- a/src/plugins/saved_search/common/content_management/v1/cm_services.ts
+++ b/src/plugins/saved_search/common/content_management/v1/cm_services.ts
@@ -110,6 +110,7 @@ const savedSearchCreateOptionsSchema = schema.maybe(
 const savedSearchUpdateOptionsSchema = schema.maybe(
   schema.object({
     references: updateOptionsSchema.references,
+    mergeAttributes: updateOptionsSchema.mergeAttributes,
   })
 );
 const savedSearchSearchOptionsSchema = schema.maybe(

--- a/src/plugins/saved_search/common/content_management/v1/types.ts
+++ b/src/plugins/saved_search/common/content_management/v1/types.ts
@@ -23,6 +23,7 @@ interface SavedSearchCreateOptions {
 
 interface SavedSearchUpdateOptions {
   references?: SavedObjectUpdateOptions['references'];
+  mergeAttributes?: SavedObjectUpdateOptions['mergeAttributes'];
 }
 
 interface SavedSearchSearchOptions {

--- a/src/plugins/saved_search/common/service/saved_searches_utils.ts
+++ b/src/plugins/saved_search/common/service/saved_searches_utils.ts
@@ -8,7 +8,6 @@
 
 import type { SavedObjectReference } from '@kbn/core-saved-objects-server';
 import { SerializedSearchSourceFields } from '@kbn/data-plugin/common';
-import { pick } from 'lodash';
 import type { SavedSearch, SavedSearchAttributes } from '..';
 import { fromSavedSearchAttributes as fromSavedSearchAttributesCommon } from '..';
 import { SerializableSavedSearch } from '../types';
@@ -48,7 +47,7 @@ export const toSavedSearchAttributes = (
   isTextBasedQuery: savedSearch.isTextBasedQuery ?? false,
   usesAdHocDataView: savedSearch.usesAdHocDataView,
   timeRestore: savedSearch.timeRestore ?? false,
-  timeRange: savedSearch.timeRange ? pick(savedSearch.timeRange, ['from', 'to']) : undefined,
+  timeRange: savedSearch.timeRange,
   refreshInterval: savedSearch.refreshInterval,
   rowsPerPage: savedSearch.rowsPerPage,
   sampleSize: savedSearch.sampleSize,

--- a/src/plugins/saved_search/public/services/saved_searches/save_saved_searches.ts
+++ b/src/plugins/saved_search/public/services/saved_searches/save_saved_searches.ts
@@ -28,6 +28,14 @@ export const saveSearchSavedObject = async (
   references: Reference[] | undefined,
   contentManagement: ContentManagementPublicStart['client']
 ) => {
+  const definedAttributes = Object.keys(attributes).reduce(
+    (prev: SavedSearchAttributes, key: string) => {
+      return attributes[key as keyof SavedSearchAttributes] || key === 'description'
+        ? { ...prev, [key]: attributes[key as keyof SavedSearchAttributes] }
+        : prev;
+    },
+    {} as SavedSearchAttributes
+  );
   const resp = id
     ? await contentManagement.update<
         SavedSearchCrudTypes['UpdateIn'],
@@ -35,9 +43,10 @@ export const saveSearchSavedObject = async (
       >({
         contentTypeId: SAVED_SEARCH_TYPE,
         id,
-        data: attributes,
+        data: definedAttributes,
         options: {
           references,
+          mergeAttributes: false,
         },
       })
     : await contentManagement.create<
@@ -50,7 +59,6 @@ export const saveSearchSavedObject = async (
           references,
         },
       });
-
   return resp.item.id;
 };
 

--- a/src/plugins/unified_search/public/query_string_input/query_bar_top_row.tsx
+++ b/src/plugins/unified_search/public/query_string_input/query_bar_top_row.tsx
@@ -158,6 +158,7 @@ export interface QueryBarTopRowProps<QT extends Query | AggregateQuery = Query> 
   showAddFilter?: boolean;
   showDatePicker?: boolean;
   isDisabled?: boolean;
+  disableQueryInput?: boolean;
   showAutoRefreshOnly?: boolean;
   timeHistory?: TimeHistoryContract;
   timeRangeForSuggestionsOverride?: boolean;
@@ -700,7 +701,7 @@ export const QueryBarTopRow = React.memo(
                 prepend={renderFilterMenuOnly() && renderFilterButtonGroup()}
                 size={props.suggestionsSize}
                 suggestionsAbstraction={props.suggestionsAbstraction}
-                isDisabled={props.isDisabled}
+                isDisabled={props.isDisabled || props.disableQueryInput}
                 appName={appName}
                 submitOnBlur={props.submitOnBlur}
                 deps={{

--- a/src/plugins/unified_search/public/query_string_input/query_bar_top_row.tsx
+++ b/src/plugins/unified_search/public/query_string_input/query_bar_top_row.tsx
@@ -159,6 +159,7 @@ export interface QueryBarTopRowProps<QT extends Query | AggregateQuery = Query> 
   showDatePicker?: boolean;
   isDisabled?: boolean;
   disableQueryInput?: boolean;
+  disableAutoRefresh?: boolean;
   showAutoRefreshOnly?: boolean;
   timeHistory?: TimeHistoryContract;
   timeRangeForSuggestionsOverride?: boolean;
@@ -505,7 +506,7 @@ export const QueryBarTopRow = React.memo(
           refreshInterval={props.refreshInterval}
           onTimeChange={onTimeChange}
           onRefresh={onRefresh}
-          onRefreshChange={props.onRefreshChange}
+          onRefreshChange={props.disableAutoRefresh ? undefined : props.onRefreshChange}
           showUpdateButton={false}
           recentlyUsedRanges={recentlyUsedRanges}
           locale={i18n.getLocale()}

--- a/src/plugins/unified_search/public/search_bar/create_search_bar.tsx
+++ b/src/plugins/unified_search/public/search_bar/create_search_bar.tsx
@@ -44,6 +44,7 @@ export type StatefulSearchBarProps<QT extends Query | AggregateQuery = Query> = 
   onSavedQueryIdChange?: (savedQueryId?: string) => void;
   onFiltersUpdated?: (filters: Filter[]) => void;
   disableQueryInput?: boolean;
+  disableAutoRefresh?: boolean;
 };
 
 // Respond to user changing the filters
@@ -228,6 +229,7 @@ export function createSearchBar({
             submitButtonStyle={props.submitButtonStyle}
             isDisabled={props.isDisabled}
             disableQueryInput={props.disableQueryInput}
+            disableAutoRefresh={props.disableAutoRefresh}
             screenTitle={props.screenTitle}
             indexPatterns={props.indexPatterns}
             indicateNoData={props.indicateNoData}

--- a/src/plugins/unified_search/public/search_bar/create_search_bar.tsx
+++ b/src/plugins/unified_search/public/search_bar/create_search_bar.tsx
@@ -43,6 +43,7 @@ export type StatefulSearchBarProps<QT extends Query | AggregateQuery = Query> = 
   saveQueryMenuVisibility?: SavedQueryMenuVisibility;
   onSavedQueryIdChange?: (savedQueryId?: string) => void;
   onFiltersUpdated?: (filters: Filter[]) => void;
+  disableQueryInput?: boolean;
 };
 
 // Respond to user changing the filters
@@ -157,6 +158,7 @@ export function createSearchBar({
     const { useDefaultBehaviors } = props;
     // Handle queries
     const onQuerySubmitRef = useRef(props.onQuerySubmit);
+    console.log('test', props.disableQueryInput);
 
     useEffect(() => {
       onQuerySubmitRef.current = props.onQuerySubmit;
@@ -226,6 +228,7 @@ export function createSearchBar({
             showSubmitButton={props.showSubmitButton}
             submitButtonStyle={props.submitButtonStyle}
             isDisabled={props.isDisabled}
+            disableQueryInput={props.disableQueryInput}
             screenTitle={props.screenTitle}
             indexPatterns={props.indexPatterns}
             indicateNoData={props.indicateNoData}

--- a/src/plugins/unified_search/public/search_bar/create_search_bar.tsx
+++ b/src/plugins/unified_search/public/search_bar/create_search_bar.tsx
@@ -158,7 +158,6 @@ export function createSearchBar({
     const { useDefaultBehaviors } = props;
     // Handle queries
     const onQuerySubmitRef = useRef(props.onQuerySubmit);
-    console.log('test', props.disableQueryInput);
 
     useEffect(() => {
       onQuerySubmitRef.current = props.onQuerySubmit;

--- a/src/plugins/unified_search/public/search_bar/search_bar.tsx
+++ b/src/plugins/unified_search/public/search_bar/search_bar.tsx
@@ -126,6 +126,7 @@ export interface SearchBarOwnProps<QT extends AggregateQuery | Query = Query> {
    * Disables all inputs and interactive elements,
    */
   isDisabled?: boolean;
+  disableQueryInput?: boolean;
 
   submitOnBlur?: boolean;
 
@@ -615,6 +616,7 @@ class SearchBarUI<QT extends (Query | AggregateQuery) | Query = Query> extends C
           showAutoRefreshOnly={this.props.showAutoRefreshOnly}
           showQueryInput={this.props.showQueryInput}
           showAddFilter={this.props.showFilterBar}
+          disableQueryInput={this.props.disableQueryInput}
           isDisabled={this.props.isDisabled}
           onRefresh={this.props.onRefresh}
           onRefreshChange={this.props.onRefreshChange}

--- a/src/plugins/unified_search/public/search_bar/search_bar.tsx
+++ b/src/plugins/unified_search/public/search_bar/search_bar.tsx
@@ -127,6 +127,7 @@ export interface SearchBarOwnProps<QT extends AggregateQuery | Query = Query> {
    */
   isDisabled?: boolean;
   disableQueryInput?: boolean;
+  disableAutoRefresh?: boolean;
 
   submitOnBlur?: boolean;
 
@@ -617,6 +618,7 @@ class SearchBarUI<QT extends (Query | AggregateQuery) | Query = Query> extends C
           showQueryInput={this.props.showQueryInput}
           showAddFilter={this.props.showFilterBar}
           disableQueryInput={this.props.disableQueryInput}
+          disableAutoRefresh={this.props.disableAutoRefresh}
           isDisabled={this.props.isDisabled}
           onRefresh={this.props.onRefresh}
           onRefreshChange={this.props.onRefreshChange}


### PR DESCRIPTION
Branched from https://github.com/elastic/kibana/pull/180536

> [!WARNING]
> This PR is just a proof of concept - I made some changes to behaviour that would need a longer discussion before it is ready to be merged. Would also definitely need some design help 🙈 

## Summary
  
This PR is a proof of concept for inline editing + creation for the saved search embeddable. When creating a new saved search embeddable via the dashboard, I opted to **only** include ES|QL editing - however, editing existing saved search embeddables based on data views is also supported.


### Data view

Note that, in the following video, opening the editor flyout causes the "Auto refresh" option to be removed from the time picker in the unified search bar - this is because auto-refresh is not applicable at a panel level.


https://github.com/Heenawter/kibana/assets/8698078/a0c7a515-9f2f-4ba2-81d0-4159f9687bc8




### ES|QL 


Note that, in the following video, opening the editor flyout causes everything in the unified search bar **except** the time filter to get disabled - that is because the time range is the only applicable local filter for ES|QL saved searches. The auto-refresh is also removed in this editor, just like for data view saved searches.


https://github.com/Heenawter/kibana/assets/8698078/501c8ad0-7574-4db7-883f-b46ae8f354dd



### Other notes

As part of this, I also made a few changes to the saved search embeddable to make its behaviour more consistent with other embeddables: 
1. The saved search embeddable no longer ignores its local time range in favour of the dashboard one - instead, the saved search exposes this custom time range via the panel custom time range action
2. The saved search now exposes its filters via the panel filters action
3. If the search is saved to the library, then the library item gets updated when the dashboard is saved.

